### PR TITLE
Layout fix for ubuntu / mint

### DIFF
--- a/src/accueil.c
+++ b/src/accueil.c
@@ -1754,7 +1754,7 @@ GtkWidget *creation_onglet_accueil ( void )
     devel_debug ( NULL );
 
     vbox = gtk_box_new ( GTK_ORIENTATION_VERTICAL, 15 );
-    gtk_widget_set_hexpand (button, TRUE);
+    gtk_widget_set_vexpand (vbox, TRUE);
     gtk_widget_show ( vbox );
 
     /* on met le titre du fichier */

--- a/src/accueil.c
+++ b/src/accueil.c
@@ -1754,6 +1754,7 @@ GtkWidget *creation_onglet_accueil ( void )
     devel_debug ( NULL );
 
     vbox = gtk_box_new ( GTK_ORIENTATION_VERTICAL, 15 );
+    gtk_widget_set_hexpand (button, TRUE);
     gtk_widget_show ( vbox );
 
     /* on met le titre du fichier */

--- a/src/navigation.c
+++ b/src/navigation.c
@@ -211,6 +211,7 @@ GtkWidget *gsb_gui_navigation_create_navigation_pane ( void )
     grid = gtk_grid_new ();
 
     sw = gtk_scrolled_window_new (NULL, NULL);
+    gtk_widget_set_vexpand (sw, TRUE);
     gtk_scrolled_window_set_shadow_type (GTK_SCROLLED_WINDOW (sw), GTK_SHADOW_ETCHED_IN);
     gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (sw),
                                     GTK_POLICY_AUTOMATIC,


### PR DESCRIPTION
Hello,

the master branch compiles on my Mint 17 (libgtk-dev 3.18.9) but the tree widget on the left-hand side is squished into a single line, making any navigation impossible.

On my system, the fix was to add a set_vexpand (sw,TRUE) statement in gsb_gui_navigation_create_navigation_pane ( void ) in navigation.c:

    sw = gtk_scrolled_window_new (NULL, NULL);
    gtk_widget_set_vexpand (sw, TRUE);

Similarly, adding 

    vbox = gtk_box_new ( GTK_ORIENTATION_VERTICAL, 15 );
    gtk_widget_set_vexpand (vbox, TRUE);

to creation_onglet_accueil ( void ) in accueil.c expands the right-hand side widgets all the way to the bottom. Actually, fixing creation_onglet_accueil ( void ) seems to fix all the other "onglets" as well. The reports for example, correctly expand to the bottom of the window.

Hope this helps! Many thanks for writing Grisbi (super le soft, merci!).

Kind regards,
Egor