### PR TITLE
Fix compil with GTK < 3.22

### DIFF
--- a/src/utils_buttons.h
+++ b/src/utils_buttons.h
@@ -24,7 +24,7 @@ GtkWidget *     new_image_label                                 (GsbButtonStyle 
 GtkWidget *     new_stock_image_label                           (GsbButtonStyle style,
                                                                  const gchar *stock_id,
                                                                  const gchar *name);
-#if GTK_CHECK_VERSION (3,22,0)
+#if !GTK_CHECK_VERSION (3,22,0)
 void            set_popup_position                              (GtkMenu *menu,
                                                                  gint *x,
                                                                  gint *y,


### PR DESCRIPTION
I believe this is a regression which was introduced when the code was adapted to use new popup menu functions after the deprecation of gtk_menu_popup in gtk-3.22.

Btw it's my first Github pull request!
I haven't coded in C for many years, and never with GTK, so I fought a bit to find out why Grisbi was not compiling anymore (I am on  LinuxMint 18 based on Ubuntu LTS, which uses GTK 3.18).
I have been using Grisbi for over 12 years, I love it, though I see many things which could be improved... so while looking at the source I tried to code some of them, but miserably failed T_T
It's too bad, because I would be glad to contribute, but GTK doesn't seem so simple to dive in.