### PR TITLE
Use english format for number in QIF export

### DIFF
--- a/src/qif.c
+++ b/src/qif.c
@@ -884,7 +884,7 @@ gboolean qif_export ( const gchar *filename,
 			  g_date_get_year (gsb_data_transaction_get_date (transaction_number_tmp)));
 
 		/* met le solde initial */
-		tmpstr = utils_real_get_string (gsb_data_account_get_init_balance (account_nb, -1));
+		tmpstr = utils_real_get_string_intl (gsb_data_account_get_init_balance (account_nb, -1));
 		fprintf ( fichier_qif,
 			  "T%s\n",
 			  tmpstr);
@@ -939,7 +939,7 @@ gboolean qif_export ( const gchar *filename,
 
 
 		/* met le montant, transforme la devise si necessaire */
-		tmpstr = utils_real_get_string (gsb_data_transaction_get_adjusted_amount ( transaction_number_tmp, floating_point));
+		tmpstr = utils_real_get_string_intl (gsb_data_transaction_get_adjusted_amount ( transaction_number_tmp, floating_point));
 		fprintf ( fichier_qif,
 			  "T%s\n",
 			  tmpstr);
@@ -1034,7 +1034,7 @@ gboolean qif_export ( const gchar *filename,
 
 			    /* set the amount of the split child */
 
-			    tmpstr = utils_real_get_string (gsb_data_transaction_get_adjusted_amount (transaction_number_tmp_2, floating_point));
+			    tmpstr = utils_real_get_string_intl (gsb_data_transaction_get_adjusted_amount (transaction_number_tmp_2, floating_point));
 			    fprintf ( fichier_qif,
 				      "$%s\n",
 				      tmpstr);

--- a/src/utils_real.c
+++ b/src/utils_real.c
@@ -57,6 +57,32 @@ gchar *utils_real_get_string ( gsb_real number )
     return gsb_real_raw_format_string ( number, locale, NULL );
 }
 
+/**
+ * Return the real in a formatted string, according to the currency
+ * or negative sign and
+ * with "." as decimal separator and "," as thousands separator.
+ *
+ * This is used to export values in an international format so it
+ * can be imported in another application.
+ *
+ * this is directly the number coded in the real wich is returned
+ * usually, utils_real_get_string_with_currency is better to adapt the format
+ * 	of the number to the currency format
+ *
+ * \param number	Number to format.
+ *
+ * \return		A newly allocated string of the number (this
+ *			function will never return NULL)
+ */
+gchar *utils_real_get_string_intl ( gsb_real number )
+{
+	struct lconv locale = *gsb_locale_get_locale ();
+	locale.mon_decimal_point = ".";
+	locale.mon_thousands_sep = ",";
+
+	gchar *a = gsb_real_raw_format_string ( number, &locale, NULL );
+	return a;
+}
 
 /**
  * Return the real in a formatted string with an optional currency

--- a/src/utils_real.h
+++ b/src/utils_real.h
@@ -8,6 +8,7 @@
 /* END_INCLUDE_H */
 
 gchar *utils_real_get_string ( gsb_real number );
+gchar *utils_real_get_string_intl ( gsb_real number );
 
 gchar *utils_real_get_string_with_currency ( gsb_real number,
                         gint currency_number,


### PR DESCRIPTION
Use "." as decimal separator and "," as thousands separator in QIF export.

Fixes Debian bug #742777
" grisbi: qif export - wrong amount format (French while should be English in all cases) "
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=742777