### PR TITLE
Windows 32bit & 64bit through AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,52 +1,47 @@
 version: 1.0.{build}
 image: Visual Studio 2017
 clone_folder: c:\projects\grisbi-src
+init:
+- cmd: >-
+    c:\msys64\usr\bin\bash -lc "echo MSYSTEM=%MSYSTEM% > /appveyor.environment"
+
+
+    c:\msys64\usr\bin\bash -lc "pacman -S unzip --noconfirm"
+
+
+    c:\msys64\usr\bin\bash -lc "wget -O /nsis.zip \"https://sourceforge.net/projects/nsis/files/NSIS 3/3.02.1/nsis-3.02.1.zip/download?use_mirror=kent\""
+
+    c:\msys64\usr\bin\bash -lc "cd / && unzip nsis.zip"
+environment:
+  matrix:
+  - MSYSTEM: MINGW32
+  - MSYSTEM: MINGW64
 install:
 - cmd: >-
-    c:\msys64\usr\bin\bash -lc "pacman -Syu --noconfirm"
+    c:\msys64\usr\bin\bash -lc "cd /c/projects/grisbi-src/share && ./appveyor-install.sh"
 
-    c:\msys64\usr\bin\bash -lc "pacman -S --noconfirm mingw-w64-x86_64-cairo"
-
-    c:\msys64\usr\bin\bash -lc "pacman -S --noconfirm mingw-w64-x86_64-gtk3"
-
-
-    c:\msys64\usr\bin\bash -lc "pacman -S --noconfirm mingw-w64-x86_64-freetype"
-
-    c:\msys64\usr\bin\bash -lc "pacman -S --noconfirm mingw-w64-x86_64-libgsf"
-    
-    
-    c:\msys64\usr\bin\bash -lc "pacman -S unzip --noconfirm"
+    c:\msys64\usr\bin\bash -lc "ls /mingw*/share/glib-2.0/schemas/gschema.dtd"
 build_script:
-- cmd: >-
-    rem Setting variable is mandatory so that pkg-config to find
-
-    rem all .pc files. Note that we DO NOT want space after MINGW64
-
-
-    set MSYSTEM=MINGW64
-
-    c:\msys64\usr\bin\bash -lc "cd /c/projects/grisbi-src/ && ./autogen.sh"
-
-
-    c:\msys64\usr\bin\bash -lc "cd /c/projects/grisbi-src && ./configure --prefix /c/projects/grisbi-inst/"
-    
-    
-    c:\msys64\usr\bin\bash -lc "cd /c/projects/grisbi-src && v=$(grep PACKAGE_VERSION config.h | cut -f2 -d '\"'); powershell.exe -command \"Update-AppveyorBuild -Version '$v-B%APPVEYOR_BUILD_NUMBER%'\""
-
-
-    c:\msys64\usr\bin\bash -lc "cd /c/projects/grisbi-src && make -j 2"
-    
-    
-    c:\msys64\usr\bin\bash -lc "cd /c/projects/grisbi-src && make install"
-    
-    
-    c:\msys64\usr\bin\bash -lc "wget -O /nsis.zip \"https://sourceforge.net/projects/nsis/files/NSIS 3/3.02.1/nsis-3.02.1.zip/download?use_mirror=kent\""
-    
-    
-    c:\msys64\usr\bin\bash -lc "cd / && unzip nsis.zip"
-    
-    
-    c:\msys64\usr\bin\bash -lc "cd /nsis-3.02.1 && ./makensis.exe /c/projects/grisbi-src/share/grisbi.nsi"
+- cmd: c:\msys64\usr\bin\bash -lc "cd /c/projects/grisbi-src/share && ./appveyor-build.sh"
 artifacts:
-- path: share/Grisbi-x86_64-1.1.1-setup.exe
-  name: Grisbi wizard
+- path: share/Grisbi-32bit-$(appveyor_build_version)-setup.exe
+  name: Grisbi 32-bit
+- path: share/Grisbi-64bit-$(appveyor_build_version)-setup.exe
+  name: Grisbi 64-bit
+deploy:
+- provider: GitHub
+  release: v$(appveyor_build_version)
+  auth_token:
+    secure: sZu+i3QuPeW93JlxEBOJ7E1WYsAZQtIsOHVjzftLxkBvBKX/9Akt4GRYUdQWK3/Z
+  artifact: Grisbi 32-bit
+  draft: true
+  on:
+    MSYSTEM: MINGW32
+- provider: GitHub
+  release: v$(appveyor_build_version)
+  auth_token:
+    secure: sZu+i3QuPeW93JlxEBOJ7E1WYsAZQtIsOHVjzftLxkBvBKX/9Akt4GRYUdQWK3/Z
+  artifact: Grisbi 64-bit
+  draft: true
+  on:
+    MSYSTEM: MINGW64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,31 @@
+version: 1.0.{build}
+image: Visual Studio 2017
+clone_folder: c:\projects\grisbi-src
+install:
+- cmd: >-
+    c:\msys64\usr\bin\bash -lc "pacman -Syu --noconfirm"
+
+    c:\msys64\usr\bin\bash -lc "pacman -S --noconfirm mingw-w64-x86_64-cairo"
+
+    c:\msys64\usr\bin\bash -lc "pacman -S --noconfirm mingw-w64-x86_64-gtk3"
+
+
+    c:\msys64\usr\bin\bash -lc "pacman -S --noconfirm mingw-w64-x86_64-freetype"
+
+    c:\msys64\usr\bin\bash -lc "pacman -S --noconfirm mingw-w64-x86_64-libgsf"
+build_script:
+- cmd: >-
+    rem Setting variable is mandatory so that pkg-config to find
+
+    rem all .pc files. Note that we DO NOT want space after MINGW64
+
+
+    set MSYSTEM=MINGW64
+
+    c:\msys64\usr\bin\bash -lc "cd /c/projects/grisbi-src/ && ./autogen.sh"
+
+
+    c:\msys64\usr\bin\bash -lc "cd /c/projects/grisbi-src && ./configure"
+
+
+    c:\msys64\usr\bin\bash -lc "cd /c/projects/grisbi-src && make -j 4"

--- a/configure.ac
+++ b/configure.ac
@@ -290,6 +290,18 @@ case $host_os in
     ;;
 esac
 
+if test "$platform_win" = "yes"; then
+	NSIS_BITS=64bit
+	NSIS_DEFAULTINSTDIR="Program Files"
+	if test "$MSYSTEM"x == "MINGW32"x; then
+		NSIS_BITS=32bit;
+		NSIS_DEFAULTINSTDIR="Program Files (x86)"
+	fi
+	AC_SUBST(NSIS_BITS)
+	AC_SUBST(NSIS_DEFAULTINSTDIR)
+fi
+
+
 AM_CONDITIONAL(WIN32, test "$platform_win" = "yes")
 
 dnl ================================================================

--- a/configure.ac
+++ b/configure.ac
@@ -66,13 +66,6 @@ dnl new warning from ar
 AR_FLAGS='cr'
 AC_SUBST(AR_FLAGS)
 
-dnl NSIS support (for Windows packaging)
-NSIS_SRCDIR=$({ cd ${srcdir} && pwd -W; } | sed 's|/|\\|g')
-NSIS_INSTDIR=$(echo $prefix | perl -p -e 's|^/(.)/|$1:\\|' | perl -p -e 's|/|\\|g')
-
-AC_SUBST(NSIS_SRCDIR)
-AC_SUBST(NSIS_INSTDIR)
-
 dnl ================================================================
 dnl Check for NLS support.
 dnl ================================================================
@@ -297,8 +290,15 @@ if test "$platform_win" = "yes"; then
 		NSIS_BITS=32bit;
 		NSIS_DEFAULTINSTDIR="Program Files (x86)"
 	fi
+	NSIS_SRCDIR=$({ cd ${srcdir} && pwd -W; } | sed 's|/|\\|g')
+	NSIS_INSTDIR=$(echo $prefix | perl -p -e 's|^/(.)/|$1:\\|' | perl -p -e 's|/|\\|g')
+	
 	AC_SUBST(NSIS_BITS)
 	AC_SUBST(NSIS_DEFAULTINSTDIR)
+	
+
+	AC_SUBST(NSIS_SRCDIR)
+	AC_SUBST(NSIS_INSTDIR)
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -66,6 +66,13 @@ dnl new warning from ar
 AR_FLAGS='cr'
 AC_SUBST(AR_FLAGS)
 
+dnl NSIS support (for Windows packaging)
+NSIS_SRCDIR=$({ cd ${srcdir} && pwd -W; } | sed 's|/|\\|g')
+NSIS_INSTDIR=$(echo $prefix | perl -p -e 's|^/(.)/|$1:\\|' | perl -p -e 's|/|\\|g')
+
+AC_SUBST(NSIS_SRCDIR)
+AC_SUBST(NSIS_INSTDIR)
+
 dnl ================================================================
 dnl Check for NLS support.
 dnl ================================================================
@@ -279,10 +286,10 @@ case $host_os in
   ;;
   *)
     platform_win=no
+    AC_MSG_RESULT([$platform_win])    
     ;;
 esac
 
-AC_MSG_RESULT([$platform_win])
 AM_CONDITIONAL(WIN32, test "$platform_win" = "yes")
 
 dnl ================================================================
@@ -358,6 +365,7 @@ pixmaps/Makefile
 pixmaps/flags/Makefile
 po/Makefile.in
 share/Makefile
+share/grisbi.nsi
 share/categories/Makefile
 share/categories/C/Makefile
 share/categories/fr/Makefile

--- a/share/Makefile.am
+++ b/share/Makefile.am
@@ -5,7 +5,7 @@ desktop_in_files = grisbi.desktop.in
 desktop_DATA = $(desktop_in_files:.desktop.in=.desktop)
 @INTLTOOL_DESKTOP_RULE@
 
-EXTRA_DIST = $(desktop_in_files) grisbi.xml
+EXTRA_DIST = $(desktop_in_files) grisbi.xml grisbi.nsi.in
 
 mimedir = $(datadir)/mime/packages
 mime_DATA = grisbi.xml
@@ -71,4 +71,5 @@ if WIN32
 	/mingw64/share/locale/de/LC_MESSAGES/gtk30-properties.mo \
 	/mingw64/share/locale/de/LC_MESSAGES/glib20.mo \
 	$(prefix)/share/locale/de/LC_MESSAGES/;
+	echo "Use makensisw.exe from NSIS (http://nsis.sourceforget.net/) on $(bindir)/share/grisbi.nsi";
 endif

--- a/share/Makefile.am
+++ b/share/Makefile.am
@@ -31,7 +31,7 @@ DISTCLEANFILES = $(desktop_DATA)
 # Notice that many data files are copied that might be useless for
 # Grisbi at this time...
 
-auto_dependencies=`ldd $(prefix)/bin/grisbi.exe | grep mingw64 | cut -f2 -d'>' | cut -f2 -d' '`
+auto_dependencies=`ntldd -R $(prefix)/bin/grisbi.exe | grep "mingw64\|mingw32" | cut -f2 -d'>' | cut -f2 -d' '`
 
 install-exec-hook:
 if WIN32
@@ -46,30 +46,33 @@ if WIN32
 	strip $(prefix)/bin/grisbi.exe;
 	echo "Copying glib-2.0 schemas";
 	if test ! -d $(prefix)/share/glib-2.0/schemas/; then mkdir -p $(prefix)/share/glib-2.0/schemas/; fi;
-	cp -v /mingw64/share/glib-2.0/schemas/gschema.dtd \
-	/mingw64/share/glib-2.0/schemas/org.gtk.Settings.FileChooser.gschema.xml \
-	/mingw64/share/glib-2.0/schemas/org.gtk.Settings.ColorChooser.gschema.xml \
-	$(prefix)/share/glib-2.0/schemas/;
-	glib-compile-schemas $(prefix)/share/glib-2.0/schemas/;
-	gdk_pixbuf_ver=`pkg-config.exe gdk-pixbuf-2.0 --variable=gdk_pixbuf_binary_version`;
-	echo "Copying gdk-pixbuf cache file ($$gdk_pixbuf_ver)";
-	mkdir -p $(prefix)/lib/gdk-pixbuf-2.0/$$gdk_pixbuf_ver;
-	cp `pkg-config.exe gdk-pixbuf-2.0 --variable=gdk_pixbuf_cache_file` $(prefix)/lib/gdk-pixbuf-2.0/$$gdk_pixbuf_ver;
-	if test ! -d $(prefix)/share/icons/; then mkdir -p $(prefix)/share/icons; fi;
-	echo "Copying hicolor icons";
-	cp -rf /mingw64/share/icons/hicolor $(prefix)/share/icons/;
-	echo "Copying Adwaita icons";
-	cp -rf /mingw64/share/icons/Adwaita $(prefix)/share/icons/;
-	echo "Copying LC_MESSAGES for GTK";
-	if test ! -d $(prefix)/share/locale/fr/LC_MESSAGES/; then mkdir -p $(prefix)/share/locale/fr/LC_MESSAGES/; fi;
-	cp -v /mingw64/share/locale/fr/LC_MESSAGES/gtk30.mo \
-	/mingw64/share/locale/fr/LC_MESSAGES/gtk30-properties.mo \
-	/mingw64/share/locale/fr/LC_MESSAGES/glib20.mo \
-	$(prefix)/share/locale/fr/LC_MESSAGES/;
-	if test ! -d $(prefix)/share/locale/de/LC_MESSAGES/; then mkdir -p $(prefix)/share/locale/de/LC_MESSAGES/; fi;
-	cp -v /mingw64/share/locale/de/LC_MESSAGES/gtk30.mo \
-	/mingw64/share/locale/de/LC_MESSAGES/gtk30-properties.mo \
-	/mingw64/share/locale/de/LC_MESSAGES/glib20.mo \
+	bits=64; \
+	export bits; \
+	if test "$$MSYSTEM"x == "MINGW32"x; then bits=32; fi; \
+	cp -v /mingw$$bits/share/glib-2.0/schemas/gschema.dtd \
+	/mingw$$bits/share/glib-2.0/schemas/org.gtk.Settings.FileChooser.gschema.xml \
+	/mingw$$bits/share/glib-2.0/schemas/org.gtk.Settings.ColorChooser.gschema.xml \
+	$(prefix)/share/glib-2.0/schemas/; \
+	glib-compile-schemas $(prefix)/share/glib-2.0/schemas/; \
+	gdk_pixbuf_ver=`pkg-config.exe gdk-pixbuf-2.0 --variable=gdk_pixbuf_binary_version`; \
+	echo "Copying gdk-pixbuf cache file ($$gdk_pixbuf_ver)"; \
+	mkdir -p $(prefix)/lib/gdk-pixbuf-2.0/$$gdk_pixbuf_ver; \
+	cp `pkg-config.exe gdk-pixbuf-2.0 --variable=gdk_pixbuf_cache_file` $(prefix)/lib/gdk-pixbuf-2.0/$$gdk_pixbuf_ver; \
+	if test ! -d $(prefix)/share/icons/; then mkdir -p $(prefix)/share/icons; fi; \
+	echo "Copying hicolor icons"; \
+	cp -rf /mingw$$bits/share/icons/hicolor $(prefix)/share/icons/; \
+	echo "Copying Adwaita icons"; \
+	cp -rf /mingw$$bits/share/icons/Adwaita $(prefix)/share/icons/; \
+	echo "Copying LC_MESSAGES for GTK"; \
+	if test ! -d $(prefix)/share/locale/fr/LC_MESSAGES/; then mkdir -p $(prefix)/share/locale/fr/LC_MESSAGES/; fi; \
+	cp -v /mingw$$bits/share/locale/fr/LC_MESSAGES/gtk30.mo \
+	/mingw$$bits/share/locale/fr/LC_MESSAGES/gtk30-properties.mo \
+	/mingw$$bits/share/locale/fr/LC_MESSAGES/glib20.mo \
+	$(prefix)/share/locale/fr/LC_MESSAGES/; \
+	if test ! -d $(prefix)/share/locale/de/LC_MESSAGES/; then mkdir -p $(prefix)/share/locale/de/LC_MESSAGES/; fi; \
+	cp -v /mingw$$bits/share/locale/de/LC_MESSAGES/gtk30.mo \
+	/mingw$$bits/share/locale/de/LC_MESSAGES/gtk30-properties.mo \
+	/mingw$$bits/share/locale/de/LC_MESSAGES/glib20.mo \
 	$(prefix)/share/locale/de/LC_MESSAGES/;
-	echo "Use makensisw.exe from NSIS (http://nsis.sourceforget.net/) on $(bindir)/share/grisbi.nsi";
+	echo "Use makensis[w].exe from NSIS (http://nsis.sourceforget.net/) on $(bindir)/share/grisbi.nsi";
 endif

--- a/share/appveyor-build.sh
+++ b/share/appveyor-build.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+source /appveyor.environment
+export MSYSTEM
+
+cd /c/projects/grisbi-src
+./autogen.sh
+./configure --prefix /c/projects/grisbi-inst/
+
+v=$(grep PACKAGE_VERSION config.h | cut -f2 -d '"')
+powershell.exe -command "Update-AppveyorBuild -Version \"$v\""
+# -B%APPVEYOR_BUILD_NUMBER%\""
+
+make -j 2
+
+make install
+
+cd /nsis-3.02.1
+./makensis.exe /c/projects/grisbi-src/share/grisbi.nsi

--- a/share/appveyor-install.sh
+++ b/share/appveyor-install.sh
@@ -1,12 +1,17 @@
 #!/bin/sh
 
-if test "$MSYSTEM"x == "MINGW64"; then
-	i_pkg_postfix = "w64-x86_64"
+source /appveyor.environment
+export MSYSTEM
+
+if test "$MSYSTEM"x == "MINGW64"x; then
+	i_pkg_postfix="w64-x86_64"
+else
+	i_pkg_postfix="w64-i686"
 fi
 
-pacman -Syu --noconfirm
+pacman -S --noconfirm mingw-glib2-devel
 pacman -S --noconfirm mingw-$i_pkg_postfix-cairo
 pacman -S --noconfirm mingw-$i_pkg_postfix-gtk3
 pacman -S --noconfirm mingw-$i_pkg_postfix-freetype
-pacman -S --noconfirm mingw-$i_pkg_postfix-libgsf  
-pacman -S unzip --noconfirm
+pacman -S --noconfirm mingw-$i_pkg_postfix-libgsf 
+pacman -S --noconfirm mingw-$i_pkg_postfix-ntldd-git

--- a/share/appveyor-install.sh
+++ b/share/appveyor-install.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+if test "$MSYSTEM"x == "MINGW64"; then
+	i_pkg_postfix = "w64-x86_64"
+fi
+
+pacman -Syu --noconfirm
+pacman -S --noconfirm mingw-$i_pkg_postfix-cairo
+pacman -S --noconfirm mingw-$i_pkg_postfix-gtk3
+pacman -S --noconfirm mingw-$i_pkg_postfix-freetype
+pacman -S --noconfirm mingw-$i_pkg_postfix-libgsf  
+pacman -S unzip --noconfirm

--- a/share/grisbi.nsi.in
+++ b/share/grisbi.nsi.in
@@ -18,14 +18,16 @@ RequestExecutionLevel admin
 !define PACKAGERDIR "@NSIS_INSTDIR@"
 !define SRCDIR "@NSIS_SRCDIR@"
 
-Name "Grisbi 64-bit"
+Name "Grisbi @NSIS_BITS@"
 Icon "${SRCDIR}\win32\grisbi.ico"
-OutFile "Grisbi-x86_64-${VERSION}-setup.exe"
+OutFile "Grisbi-@NSIS_BITS@-${VERSION}-setup.exe"
 !define COMPANYNAME "Grisbi"
 
-Caption "Grisbi 64-bit ${VERSION} Setup"
+Caption "Grisbi @NSIS_BITS@ ${VERSION} Setup"
 
-InstallDir $PROGRAMFILES64\Grisbi-${VERSION}
+# $PROGRAMFILES
+InstallDir "C:\@NSIS_DEFAULTINSTDIR@\Grisbi-${VERSION}"
+
 
 InstType "full"
 
@@ -86,11 +88,11 @@ Section "" SecBin
   WriteUninstaller "$INSTDIR\Uninstall.exe"
   
   createDirectory "$SMPROGRAMS\${COMPANYNAME}"
-  createShortCut "$SMPROGRAMS\${COMPANYNAME}\Gribi 64-bit @VERSION@.lnk" "$INSTDIR\bin\Grisbi.exe" "" "$INSTDIR\bin\grisbi.ico"
+  createShortCut "$SMPROGRAMS\${COMPANYNAME}\Gribi @NSIS_BITS@ @VERSION@.lnk" "$INSTDIR\bin\Grisbi.exe" "" "$INSTDIR\bin\grisbi.ico"
   createShortCut "$SMPROGRAMS\${COMPANYNAME}\Uninstall.lnk" "$INSTDIR\Uninstall.exe"
   
   # Registry information for add/remove programs
-  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${COMPANYNAME}" "DisplayName" "Grisbi 64-bit"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${COMPANYNAME}" "DisplayName" "Grisbi @NSIS_BITS@"
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${COMPANYNAME}" "Publisher" "Open Source"
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${COMPANYNAME}" "UninstallString" "$\"$INSTDIR\Uninstall.exe$\""
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${COMPANYNAME}" "QuietUninstallString" "$\"$INSTDIR\Uninstall.exe$\" /S"
@@ -123,7 +125,7 @@ SectionEnd
 Section "Uninstall"
   Delete "$INSTDIR\Uninstall.exe"
   Delete "$DESKTOP\Grisbi.lnk"
-  Delete "$SMPROGRAMS\${COMPANYNAME}\Gribi 64-bit @VERSION@.lnk"
+  Delete "$SMPROGRAMS\${COMPANYNAME}\Gribi @NSIS_BITS@-bit @VERSION@.lnk"
   DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${COMPANYNAME}"
 
   RMDir /r "$INSTDIR"

--- a/share/grisbi.nsi.in
+++ b/share/grisbi.nsi.in
@@ -1,0 +1,144 @@
+﻿; Source file for NSIS installer
+; http://nsis.sourceforge.net/
+
+/* "Modern UI" look */
+!include "MUI2.nsh"
+
+!define MUI_LANGDLL_ALLLANGUAGES
+
+/* Support for all languages (yet, incompatible with W95/98 & Me */
+Unicode true
+
+RequestExecutionLevel admin
+
+!ifndef VERSION
+  !define VERSION '@VERSION@'
+!endif
+
+!define PACKAGERDIR "@NSIS_INSTDIR@"
+!define SRCDIR "@NSIS_SRCDIR@"
+
+Name "Grisbi 64-bit"
+Icon "${SRCDIR}\win32\grisbi.ico"
+OutFile "Grisbi-x86_64-${VERSION}-setup.exe"
+!define COMPANYNAME "Grisbi"
+
+Caption "Grisbi 64-bit ${VERSION} Setup"
+
+InstallDir $PROGRAMFILES64\Grisbi-${VERSION}
+
+InstType "full"
+
+/* Interface */
+!define MUI_ABORTWARNING
+
+/* Pages */
+!insertmacro MUI_PAGE_WELCOME
+!insertmacro MUI_PAGE_LICENSE "${SRCDIR}\COPYING"
+!insertmacro MUI_PAGE_DIRECTORY
+!insertmacro MUI_PAGE_INSTFILES
+!define MUI_FINISHPAGE_RUN "$INSTDIR\bin\Grisbi.exe"
+; !define MUI_FINISHPAGE_RUN_TEXT "$(launchAtEnd)" 
+
+Function finishInstallDesktopShortcut
+	CreateShortCut "$DESKTOP\Grisbi.lnk" "$INSTDIR\bin\Grisbi.exe" "" "$INSTDIR\bin\grisbi.ico"
+FunctionEnd
+
+!define MUI_FINISHPAGE_SHOWREADME ""
+!define MUI_FINISHPAGE_SHOWREADME_TEXT "$(desktopShortcut)"
+!define MUI_FINISHPAGE_SHOWREADME_FUNCTION finishInstallDesktopShortcut
+
+!insertmacro MUI_PAGE_FINISH
+!insertmacro MUI_UNPAGE_INSTFILES
+
+/* Languages - first is default */
+!insertmacro MUI_LANGUAGE "English"
+!insertmacro MUI_LANGUAGE "French"
+!insertmacro MUI_LANGUAGE "Czech"
+!insertmacro MUI_LANGUAGE "Danish"
+!insertmacro MUI_LANGUAGE "German"
+!insertmacro MUI_LANGUAGE "Greek"
+!insertmacro MUI_LANGUAGE "Esperanto"
+!insertmacro MUI_LANGUAGE "Spanish"
+/* !insertmacro MUI_LANGUAGE "Persian" */
+!insertmacro MUI_LANGUAGE "Hebrew"
+!insertmacro MUI_LANGUAGE "Italian"
+!insertmacro MUI_LANGUAGE "Latvian"
+!insertmacro MUI_LANGUAGE "Dutch"
+!insertmacro MUI_LANGUAGE "Polish"
+!insertmacro MUI_LANGUAGE "Portuguese"
+!insertmacro MUI_LANGUAGE "Romanian"
+!insertmacro MUI_LANGUAGE "Russian"
+/* !insertmacro MUI_LANGUAGE "Chinese" */ 
+
+LangString desktopShortcut ${LANG_English} "Create shortcut on Desktop"
+LangString desktopShortcut ${LANG_French} "Créer une icône sur le bureau"
+
+Section "" SecBin  
+  SetOutPath "$INSTDIR\bin"   
+  File /a /r "${PACKAGERDIR}\bin\"
+  File /a "${SRCDIR}\win32\grisbi.ico"
+  
+  SetOutPath "$INSTDIR\lib"   
+  File /a /r "${PACKAGERDIR}\lib\"
+  
+  ;Create uninstaller
+  WriteUninstaller "$INSTDIR\Uninstall.exe"
+  
+  createDirectory "$SMPROGRAMS\${COMPANYNAME}"
+  createShortCut "$SMPROGRAMS\${COMPANYNAME}\Gribi 64-bit @VERSION@.lnk" "$INSTDIR\bin\Grisbi.exe" "" "$INSTDIR\bin\grisbi.ico"
+  createShortCut "$SMPROGRAMS\${COMPANYNAME}\Uninstall.lnk" "$INSTDIR\Uninstall.exe"
+  
+  # Registry information for add/remove programs
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${COMPANYNAME}" "DisplayName" "Grisbi 64-bit"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${COMPANYNAME}" "Publisher" "Open Source"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${COMPANYNAME}" "UninstallString" "$\"$INSTDIR\Uninstall.exe$\""
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${COMPANYNAME}" "QuietUninstallString" "$\"$INSTDIR\Uninstall.exe$\" /S"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${COMPANYNAME}" "InstallLocation" "$\"$INSTDIR$\""
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${COMPANYNAME}" "DisplayIcon" "$\"$INSTDIR\bin\grisbi.ico$\""    
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${COMPANYNAME}" "URLInfoAbout" "$\"http://en.grisbi.org/$\""
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${COMPANYNAME}" "DisplayVersion" "@VERSION@"
+  
+  # There is no option for modifying or repairing the install
+  WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${COMPANYNAME}" "NoModify" 1
+  WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${COMPANYNAME}" "NoRepair" 1
+  
+  # Set the INSTALLSIZE constant (!defined at the top of this script) so Add/Remove Programs can accurately report the size
+  WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${COMPANYNAME}" "EstimatedSize" 121000
+  
+  # Registry for language  
+  WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${COMPANYNAME}" "Language" $language 
+  
+  !define MUI_LANGDLL_REGISTRY_ROOT "HKLM" 
+  !define MUI_LANGDLL_REGISTRY_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${COMPANYNAME}" 
+  !define MUI_LANGDLL_REGISTRY_VALUENAME "Language"
+
+SectionEnd
+
+Section "" SecShare
+  SetOutPath "$INSTDIR\share"   
+  File /a /r "${PACKAGERDIR}\share\"
+SectionEnd
+
+Section "Uninstall"
+  Delete "$INSTDIR\Uninstall.exe"
+  Delete "$DESKTOP\Grisbi.lnk"
+  Delete "$SMPROGRAMS\${COMPANYNAME}\Gribi 64-bit @VERSION@.lnk"
+  DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${COMPANYNAME}"
+
+  RMDir /r "$INSTDIR"
+  RMDir /r "$SMPROGRAMS\${COMPANYNAME}"
+SectionEnd
+
+
+/* Installer functions */
+Function .onInit
+  !insertmacro MUI_LANGDLL_DISPLAY
+FunctionEnd
+
+/* Uninstaller functions */
+Function un.onInit  
+  !insertmacro MUI_UNGETLANGUAGE
+  ; ReadRegDWORD $language HKLM Software\Microsoft\Windows\CurrentVersion\Uninstall\${COMPANYNAME}" "Language"
+  ; !insertmacro MUI_UNGETLANGUAGE  
+FunctionEnd

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -340,6 +340,10 @@ gsettings_SCHEMAS = org.gtk.grisbi.gschema.xml
 
 @INTLTOOL_XML_NOMERGE_RULE@
 
+if WIN32
+grisbi_LDFLAGS = -mwindows
+endif
+
 SUBDIRS = ui prefs plugins/gnucash plugins/ofx plugins/openssl
 
 if HAVE_CUNIT


### PR DESCRIPTION
AppVeyor used to produce two installers for Grisbi 32 and 64bit thanks to NSIS (http://nsis.sourceforge.net) and MSYS2 (http://www.msys2.org/).

Delivery keys in appveyor.yml have to be adjusted; also, note that only autoconf's version (currently 1.1.1) is kept in AppVeyor: no build number is used for now. Thus AppVeyor may complain about duplicate version during build and/or deployment process. As a workaround, remove any previous duplicate version(s) both in AppVeyor and in github's packages' section.

I might try to improve this, but I'd probably need more clues about Grisbi's releases' naming policy.

As PoC, first wizards are available on my grisbi's fork releases.