### PR TITLE
Fix bug #0001771 (broken link to bugtracking)

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -2021,9 +2021,9 @@ msgstr "Grisbi vytvořil zálohu v '%s'."
 
 #: ../src/erreur.c:143
 msgid ""
-"Please report this problem to <tt>http://www.grisbi.org/bugtracking/</tt>.  "
+"Please report this problem to <tt>http://www.grisbi.org/bugsreports/</tt>.  "
 msgstr ""
-"Prosím nahlaste tento problém na <tt>http://www.grisbi.org/bugtracking/</tt>."
+"Prosím nahlaste tento problém na <tt>http://www.grisbi.org/bugsreports/</tt>."
 
 #: ../src/erreur.c:149
 msgid "Copy and paste the following backtrace with your bug report."

--- a/po/da.po
+++ b/po/da.po
@@ -2045,7 +2045,7 @@ msgstr ""
 
 #: ../src/erreur.c:143
 msgid ""
-"Please report this problem to <tt>http://www.grisbi.org/bugtracking/</tt>.  "
+"Please report this problem to <tt>http://www.grisbi.org/bugsreports/</tt>.  "
 msgstr ""
 
 #: ../src/erreur.c:149

--- a/po/de.po
+++ b/po/de.po
@@ -1990,9 +1990,9 @@ msgstr "Grisbi hat eine Sicherung im Verzeichnis '%s' erstellt."
 
 #: ../src/erreur.c:143
 msgid ""
-"Please report this problem to <tt>http://www.grisbi.org/bugtracking/</tt>.  "
+"Please report this problem to <tt>http://www.grisbi.org/bugsreports/</tt>.  "
 msgstr ""
-"Bitte den Fehler unter <tt>http://www.grisbi.org/bugtracking/</tt> melden.  "
+"Bitte den Fehler unter <tt>http://www.grisbi.org/bugsreports/</tt> melden.  "
 
 #: ../src/erreur.c:149
 msgid "Copy and paste the following backtrace with your bug report."

--- a/po/el.po
+++ b/po/el.po
@@ -2112,7 +2112,7 @@ msgstr "Το Grisbi έκανε ένα εφεδρικό αρχείο '%s'."
 #: ../src/erreur.c:143
 #, fuzzy
 msgid ""
-"Please report this problem to <tt>http://www.grisbi.org/bugtracking/</tt>.  "
+"Please report this problem to <tt>http://www.grisbi.org/bugsreports/</tt>.  "
 msgstr ""
 "Παρακαλώ αναφέρετε αυτό το πρόβλημα στην σελίδα <tt>http://www.grisbi.org/"
 "bugtracking/</tt>.  "

--- a/po/eo.po
+++ b/po/eo.po
@@ -1895,7 +1895,7 @@ msgstr ""
 
 #: ../src/erreur.c:143
 msgid ""
-"Please report this problem to <tt>http://www.grisbi.org/bugtracking/</tt>.  "
+"Please report this problem to <tt>http://www.grisbi.org/bugsreports/</tt>.  "
 msgstr ""
 
 #: ../src/erreur.c:149

--- a/po/es.po
+++ b/po/es.po
@@ -2071,9 +2071,9 @@ msgstr "Grisbi hizo una copia de seguridad en '%s'"
 
 #: ../src/erreur.c:143
 msgid ""
-"Please report this problem to <tt>http://www.grisbi.org/bugtracking/</tt>.  "
+"Please report this problem to <tt>http://www.grisbi.org/bugsreports/</tt>.  "
 msgstr ""
-"Por favor informe de este problema en <tt>http://www.grisbi.org/bugtracking/ "
+"Por favor informe de este problema en <tt>http://www.grisbi.org/bugsreports/ "
 "</tt>."
 
 #: ../src/erreur.c:149

--- a/po/fa.po
+++ b/po/fa.po
@@ -2003,7 +2003,7 @@ msgstr ""
 
 #: ../src/erreur.c:143
 msgid ""
-"Please report this problem to <tt>http://www.grisbi.org/bugtracking/</tt>.  "
+"Please report this problem to <tt>http://www.grisbi.org/bugsreports/</tt>.  "
 msgstr ""
 
 #: ../src/erreur.c:149

--- a/po/he.po
+++ b/po/he.po
@@ -2374,8 +2374,8 @@ msgstr "גריסבי יצר קובץ גיבוי ב '%s'."
 #: ../src/erreur.c:143
 #, fuzzy
 msgid ""
-"Please report this problem to <tt>http://www.grisbi.org/bugtracking/</tt>.  "
-msgstr "נא דווחו על בעיה זו בכתובת הבאה http://www.grisbi.org/bugtracking/"
+"Please report this problem to <tt>http://www.grisbi.org/bugsreports/</tt>.  "
+msgstr "נא דווחו על בעיה זו בכתובת הבאה http://www.grisbi.org/bugsreports/"
 
 #: ../src/erreur.c:149
 msgid "Copy and paste the following backtrace with your bug report."

--- a/po/it.po
+++ b/po/it.po
@@ -2092,7 +2092,7 @@ msgstr "Grisbi ha fatto un file di ripristino in '%s'."
 #: ../src/erreur.c:143
 #, fuzzy
 msgid ""
-"Please report this problem to <tt>http://www.grisbi.org/bugtracking/</tt>.  "
+"Please report this problem to <tt>http://www.grisbi.org/bugsreports/</tt>.  "
 msgstr ""
 "E' consigliato riportare questo problema su http://www.grisbi.org/"
 "bugtracking/"

--- a/po/lv.po
+++ b/po/lv.po
@@ -2014,7 +2014,7 @@ msgstr "Grisbi veido rezerves failu '%s'."
 #: ../src/erreur.c:143
 #, fuzzy
 msgid ""
-"Please report this problem to <tt>http://www.grisbi.org/bugtracking/</tt>.  "
+"Please report this problem to <tt>http://www.grisbi.org/bugsreports/</tt>.  "
 msgstr ""
 "Lūdzu rakstiet par šīm problēmām uz <t>htp://www.grisbi.org/bugtracking/</"
 "t>. "

--- a/po/nl.po
+++ b/po/nl.po
@@ -2120,9 +2120,9 @@ msgstr "Grisbi maakt zijn reservebestand in '%s'."
 #: ../src/erreur.c:143
 #, fuzzy
 msgid ""
-"Please report this problem to <tt>http://www.grisbi.org/bugtracking/</tt>.  "
+"Please report this problem to <tt>http://www.grisbi.org/bugsreports/</tt>.  "
 msgstr ""
-"Maak a.u.b. melding van dit probleem via http://www.grisbi.org/bugtracking/"
+"Maak a.u.b. melding van dit probleem via http://www.grisbi.org/bugsreports/"
 
 #: ../src/erreur.c:149
 msgid "Copy and paste the following backtrace with your bug report."

--- a/po/pl.po
+++ b/po/pl.po
@@ -2098,8 +2098,8 @@ msgstr "Program wykonał kopię bezpieczeństwa w '%s'."
 #: ../src/erreur.c:143
 #, fuzzy
 msgid ""
-"Please report this problem to <tt>http://www.grisbi.org/bugtracking/</tt>.  "
-msgstr "Proszę zgłosić ten problem do http://www.grisbi.org/bugtracking/"
+"Please report this problem to <tt>http://www.grisbi.org/bugsreports/</tt>.  "
+msgstr "Proszę zgłosić ten problem do http://www.grisbi.org/bugsreports/"
 
 #: ../src/erreur.c:149
 msgid "Copy and paste the following backtrace with your bug report."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -2098,9 +2098,9 @@ msgstr "Grisbi criou um arquivo de backup para %s ."
 #: ../src/erreur.c:143
 #, fuzzy
 msgid ""
-"Please report this problem to <tt>http://www.grisbi.org/bugtracking/</tt>.  "
+"Please report this problem to <tt>http://www.grisbi.org/bugsreports/</tt>.  "
 msgstr ""
-"Por favor, reporte este problema para http://www.grisbi.org/bugtracking/"
+"Por favor, reporte este problema para http://www.grisbi.org/bugsreports/"
 
 #: ../src/erreur.c:149
 msgid "Copy and paste the following backtrace with your bug report."

--- a/po/ro.po
+++ b/po/ro.po
@@ -2130,8 +2130,8 @@ msgstr "Grisbi a efectuat o copie de salvare în '%s'."
 #: ../src/erreur.c:143
 #, fuzzy
 msgid ""
-"Please report this problem to <tt>http://www.grisbi.org/bugtracking/</tt>.  "
-msgstr "Vă rugăm a anunţa această eroare la http://www.grisbi.org/bugtracking/"
+"Please report this problem to <tt>http://www.grisbi.org/bugsreports/</tt>.  "
+msgstr "Vă rugăm a anunţa această eroare la http://www.grisbi.org/bugsreports/"
 
 #: ../src/erreur.c:149
 msgid "Copy and paste the following backtrace with your bug report."

--- a/po/ru.po
+++ b/po/ru.po
@@ -2017,7 +2017,7 @@ msgstr ""
 
 #: ../src/erreur.c:143
 msgid ""
-"Please report this problem to <tt>http://www.grisbi.org/bugtracking/</tt>.  "
+"Please report this problem to <tt>http://www.grisbi.org/bugsreports/</tt>.  "
 msgstr ""
 
 #: ../src/erreur.c:149

--- a/po/sv.po
+++ b/po/sv.po
@@ -1895,7 +1895,7 @@ msgstr ""
 
 #: ../src/erreur.c:143
 msgid ""
-"Please report this problem to <tt>http://www.grisbi.org/bugtracking/</tt>.  "
+"Please report this problem to <tt>http://www.grisbi.org/bugsreports/</tt>.  "
 msgstr ""
 
 #: ../src/erreur.c:149

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -2092,8 +2092,8 @@ msgstr "Grisbi在 '%s'生成了一个备份文件。"
 #: ../src/erreur.c:143
 #, fuzzy
 msgid ""
-"Please report this problem to <tt>http://www.grisbi.org/bugtracking/</tt>.  "
-msgstr "请到 http://www.grisbi.org/bugtracking/报告错误"
+"Please report this problem to <tt>http://www.grisbi.org/bugsreports/</tt>.  "
+msgstr "请到 http://www.grisbi.org/bugsreports/报告错误"
 
 #: ../src/erreur.c:149
 msgid "Copy and paste the following backtrace with your bug report."

--- a/src/erreur.c
+++ b/src/erreur.c
@@ -140,7 +140,7 @@ void traitement_sigsegv ( gint signal_nb )
     old_errmsg = errmsg;
     errmsg = g_strconcat ( errmsg,
 			   "\n\n",
-			   _("Please report this problem to <tt>http://www.grisbi.org/bugtracking/</tt>.  "),
+			   _("Please report this problem to <tt>http://www.grisbi.org/bugsreports/</tt>.  "),
 			   NULL );
      g_free ( old_errmsg );
 

--- a/src/menu.c
+++ b/src/menu.c
@@ -521,7 +521,7 @@ gboolean help_website ( void )
  */
 gboolean help_bugreport ( void )
 {
-    lance_navigateur_web ( "http://www.grisbi.org/bugtracking/" );
+    lance_navigateur_web ( "http://www.grisbi.org/bugsreports/" );
 
     return FALSE;
 }


### PR DESCRIPTION
Update the link to the new address of the bugtracking webpage.
It basically turns 'http://www.grisbi.org/bugtracking/' into
'http://www.grisbi.org/bugsreports/' in all files of the project.