### PR TITLE
Test if reconcile final date is after each transactions dates ; fix #1814

### DIFF
--- a/src/gsb_reconcile.c
+++ b/src/gsb_reconcile.c
@@ -77,6 +77,7 @@ static gboolean gsb_reconcile_finish_reconciliation ( GtkWidget *button,
 					    gpointer null );
 static void gsb_reconcile_sensitive ( gboolean sensitive );
 static gchar *gsb_reconcile_build_label ( int reconcile_number );
+static const GDate *gsb_reconcile_get_pointed_transactions_max_date ( gint account_number );
 /*END_STATIC*/
 
 /*START_EXTERN*/

--- a/src/gsb_reconcile.c
+++ b/src/gsb_reconcile.c
@@ -528,6 +528,43 @@ gboolean gsb_reconcile_run_reconciliation ( GtkWidget *button,
 }
 
 
+/**
+ * return the date max of transactions ready to reconcile
+ *
+ * \param account_number the number of the current account
+ *
+ * \return the date max of the  transactions
+ * */
+const GDate *gsb_reconcile_get_pointed_transactions_max_date ( gint account_number )
+{
+    GSList *list_tmp;
+    const GDate *max_date = NULL;
+
+    list_tmp = gsb_data_transaction_get_complete_transactions_list ();
+
+    while (list_tmp)
+    {
+        gint transaction_number;
+        const GDate *transaction_date;
+
+        transaction_number = gsb_data_transaction_get_transaction_number ( list_tmp -> data );
+        if ( gsb_data_transaction_get_account_number (transaction_number) == account_number
+             &&
+             ( gsb_data_transaction_get_marked_transaction (transaction_number) == OPERATION_POINTEE
+               ||
+               gsb_data_transaction_get_marked_transaction (transaction_number) == OPERATION_TELERAPPROCHEE )) {
+            transaction_date = gsb_data_transaction_get_date ( transaction_number );
+            printf("transaction_date: %s\n", gsb_format_gdate ( transaction_date ));
+            if (max_date == NULL || g_date_compare (transaction_date, max_date) > 0) {
+                max_date = transaction_date;
+                printf("max_date: %s\n", gsb_format_gdate ( max_date ));
+            }
+        }
+        list_tmp = list_tmp -> next;
+    }
+    return max_date;
+}
+
 
 /**
  * finish the reconciliation,
@@ -544,6 +581,7 @@ gboolean gsb_reconcile_finish_reconciliation ( GtkWidget *button,
     GSList *list_tmp_transactions;
     GDate *date;
     const GDate *initial_date;
+    const GDate *transactions_max_date;
     gint account_number;
     gint reconcile_number;
     gsb_real real;
@@ -583,6 +621,17 @@ gboolean gsb_reconcile_finish_reconciliation ( GtkWidget *button,
 				_("Reconciliation can't be completed.") );
 	g_free ( tmp_str );
 	return FALSE;
+    }
+
+    /* teste si la date de fin inclue toutes les transactions pointées */
+    transactions_max_date = gsb_reconcile_get_pointed_transactions_max_date ( account_number );
+    if ( g_date_compare ( transactions_max_date, date ) > 0 )
+    {
+        tmp_str = g_strdup_printf ( _("Invalid date: '%s'"), gsb_format_gdate ( date ) );
+        dialogue_warning_hint ( tmp_str, _("Reconciliation can't be completed.") );
+        g_free ( tmp_str );
+
+        return FALSE;
     }
 
     /* teste la validité de la date de fin */


### PR DESCRIPTION
Tested and worked on my workstation. Maybe the error message should be more explicit, but I prefered not to break i18n by a string modification.