### PR TITLE
Fix a crash in gsb_scheduler_list_fill_list()

### DIFF
--- a/src/gsb_scheduler_list.c
+++ b/src/gsb_scheduler_list.c
@@ -958,6 +958,9 @@ gboolean gsb_scheduler_list_fill_list ( GtkWidget *tree_view )
 
     devel_debug (NULL);
 
+	if ( !tree_model_scheduler_list )
+		return FALSE;
+
     /* get the last date we want to see the transactions */
     end_date = gsb_scheduler_list_get_end_date_scheduled_showed ( );
 


### PR DESCRIPTION
Return from the function if tree_model_scheduler_list is not yet defined.

Closes: bug #1626
http://www.grisbi.org/bugsreports/view.php?id=1626