### PR TITLE
Permettre la création d'opérations dans le futur hors de l'échéancier

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -434,38 +434,42 @@ msgid "Limit the filling with payees belonging to the current account"
 msgstr "Limiter le remplissage avec des tiers appartenant au compte courant"
 
 #: ../src/affichage_liste.c:610
+msgid "Automatically adjust operation year"
+msgstr "Ajuster automatiquement l'année de l'opération"
+
+#: ../src/affichage_liste.c:616
 msgid "Mix credit/debit categories"
 msgstr "Mélanger les catégories de débit/crédit"
 
-#: ../src/affichage_liste.c:616
+#: ../src/affichage_liste.c:622
 msgid "Case sensitive completion"
 msgstr "Remplissage sensible à la casse"
 
-#: ../src/affichage_liste.c:622
+#: ../src/affichage_liste.c:628
 msgid "Don't allow new payee creation"
 msgstr "Ne pas permettre la création de nouveaux tiers"
 
-#: ../src/affichage_liste.c:628
+#: ../src/affichage_liste.c:634
 msgid "Don't allow new category/budget creation"
 msgstr "Ne pas autoriser la création de nouvelles catégories/Imputations B."
 
-#: ../src/affichage_liste.c:637
+#: ../src/affichage_liste.c:643
 msgid "Maximum items showed in drop down lists (0 for no limit): "
 msgstr ""
 "Nombre maximal de lignes dans les menus déroulants (0 pas de limite) : "
 
 #. à la base, on met une vbox
-#: ../src/affichage_liste.c:803 ../src/parametres.c:729
+#: ../src/affichage_liste.c:809 ../src/parametres.c:729
 msgid "Transactions list cells"
 msgstr "Cellules de la liste des opérations"
 
 #. partie 1 visualisation de l'arrangement des données
-#: ../src/affichage_liste.c:806
+#: ../src/affichage_liste.c:812
 msgid "Transactions list preview"
 msgstr "Prévisualisation de la liste des opérations"
 
 #. partie 2 Source des données
-#: ../src/affichage_liste.c:839
+#: ../src/affichage_liste.c:845
 msgid "Transactions list contents"
 msgstr "Contenu de la liste des opérations"
 

--- a/src/affichage_liste.c
+++ b/src/affichage_liste.c
@@ -607,6 +607,12 @@ GtkWidget *onglet_form_completion ( void )
     gtk_box_pack_start ( GTK_BOX ( hbox ), button, FALSE, FALSE, 20 );
 
     gtk_box_pack_start ( GTK_BOX (vbox_pref),
+                        gsb_automem_checkbutton_new (_("Automatically adjust operation year"),
+                        &conf.automatic_year_adjustment,
+                        NULL, NULL),
+                        FALSE, FALSE, 0 );
+
+    gtk_box_pack_start ( GTK_BOX (vbox_pref),
                         gsb_automem_checkbutton_new (_("Mix credit/debit categories"),
                         &etat.combofix_mixed_sort,
                         G_CALLBACK ( gsb_transactions_list_display_update_combofix), NULL),

--- a/src/gsb_file_config.c
+++ b/src/gsb_file_config.c
@@ -102,6 +102,7 @@ static void gsb_file_config_clean_config ( void )
     conf.limit_completion_to_current_account = 0;   /* By default, do full search */
     conf.automatic_recover_splits = 1;
     conf.automatic_erase_credit_debit = 0;
+    conf.automatic_year_adjustment = 1;
 
     conf.display_grisbi_title = GSB_ACCOUNTS_TITLE; /* show Accounts file title par défaut */
     conf.display_toolbar = GSB_BUTTON_BOTH;         /* How to display toolbar icons. */
@@ -729,6 +730,15 @@ gboolean gsb_file_config_load_config ( void )
                         "Automatic_erase_credit_debit",
                         NULL );
 
+    int_ret = g_key_file_get_integer ( config,
+                        "Display",
+                        "Automatic year adjustment",
+                        NULL );
+    if ( err == NULL )
+        conf.automatic_year_adjustment = int_ret;
+    else
+        err = NULL;
+
     conf.display_toolbar = g_key_file_get_integer ( config,
                         "Display",
                         "Display toolbar",
@@ -1077,6 +1087,11 @@ gboolean gsb_file_config_save_config ( void )
                         "Display",
                         "Automatic_erase_credit_debit",
                         conf.automatic_erase_credit_debit );
+
+    g_key_file_set_integer ( config,
+                        "Display",
+                        "Automatic year adjustment",
+                        conf.automatic_year_adjustment );
 
     g_key_file_set_integer ( config,
                         "Display",

--- a/src/structures.h
+++ b/src/structures.h
@@ -185,6 +185,7 @@ struct gsb_conf_t
     gboolean automatic_erase_credit_debit;          /* 1 pour effacer les champs crédit et débit */
     gboolean formulaire_toujours_affiche;           /* TRUE formulaire toujours affiché */
     gint affichage_exercice_automatique;            /* automatic fyear :0 to set according to the date, 1 according to value date */
+    gint automatic_year_adjustment;                  /* 1 to automatically select previous year if future date is entered */
 
 #if IS_DEVELOPMENT_VERSION == 1
     /* config file */

--- a/src/utils_dates.c
+++ b/src/utils_dates.c
@@ -45,6 +45,7 @@
 #include "navigation.h"
 #include "utils_str.h"
 #include "erreur.h"
+#include "structures.h"
 /*END_INCLUDE*/
 
 /*START_STATIC*/
@@ -326,7 +327,7 @@ GDate *gsb_parse_date_string ( const gchar *date_string )
     GRegex *date_regex;
     gchar **date_tokens = NULL;
     gchar **tab_date = NULL;
-    gboolean year_auto = TRUE;
+    gint year_auto = conf.automatic_year_adjustment;
 	gint page;
     int num_tokens, num_fields;
     int i, j;


### PR DESCRIPTION
Bonjour,

Utilisant régulièrement la possibilité qu'offrait la version 1.0.2 de saisir une opération dans le futur, même hors de l'échéancier, je n'arrive pas à me faire au nouveau fonctionnement de la v1.0.3 sur ce point (décrémentation de l'année).

Je vous propose donc que ce comportement puisse être adapté via un paramètre, le comportement de la v1.0.3 étant utilisé comme comportement par défaut.