### PR TITLE
lang detection: honor app's AppleLanguages if available

### DIFF
--- a/MacOS/Grisbi.sh
+++ b/MacOS/Grisbi.sh
@@ -50,7 +50,7 @@ unset LANG LC_MESSAGES LC_MONETARY LC_COLLATE
 # Has a language ordering been set?
 # If so, set LC_MESSAGES and LANG accordingly; otherwise skip it.
 # First step uses sed to clean off the quotes and commas, to change - to _, and change the names for the chinese scripts from "Hans" to CN and "Hant" to TW.
-if `defaults read org.grisbi.Grisbi AppleLanguages > /dev/null`; then
+if `defaults read org.grisbi.Grisbi AppleLanguages > /dev/null 2>&1`; then
     DEFAULTS_DOM="org.grisbi.Grisbi"
 else
     DEFAULTS_DOM=".GlobalPreferences"

--- a/MacOS/Grisbi.sh
+++ b/MacOS/Grisbi.sh
@@ -50,7 +50,14 @@ unset LANG LC_MESSAGES LC_MONETARY LC_COLLATE
 # Has a language ordering been set?
 # If so, set LC_MESSAGES and LANG accordingly; otherwise skip it.
 # First step uses sed to clean off the quotes and commas, to change - to _, and change the names for the chinese scripts from "Hans" to CN and "Hant" to TW.
-APPLELANGUAGES=`defaults read .GlobalPreferences AppleLanguages | sed -En   -e 's/\-/_/' -e 's/Hant/TW/' -e 's/Hans/CN/' -e 's/[[:space:]]*\"?([[:alnum:]_]+)\"?,?/\1/p' `
+if `defaults read org.grisbi.Grisbi AppleLanguages > /dev/null`; then
+    DEFAULTS_DOM="org.grisbi.Grisbi"
+else
+    DEFAULTS_DOM=".GlobalPreferences"
+fi
+APPLELANGUAGES=`defaults read $DEFAULTS_DOM AppleLanguages | sed -En   -e 's/\-/_/' -e 's/Hant/TW/' -e 's/Hans/CN/' -e 's/[[:space:]]*\"?([[:alnum:]_]+)\"?,?/\1/p' `
+unset DEFAULTS_DOM
+
 if test "$APPLELANGUAGES"; then
     # A language ordering exists.
     # Test, item per item, to see whether there is an corresponding locale.


### PR DESCRIPTION
- on MacOS it is possible to set default languages per domain/app
    like: defaults write org.grisbi.Grisbi AppleLanguages "(fr, en)"

- check if App's languages are set if not use Global defaults