### PR TITLE
AppVeyor's Windows version compilation fixed

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: 1.0.{build}
-image: Visual Studio 2017
+image: Visual Studio 2019
 clone_folder: c:\projects\grisbi-src
 # Do not build on tags
 skip_tags: true


### PR DESCRIPTION
Hi,

Using "Visual Studio 2019 image" from AppVeyor fixes compilation. I was not able to try binaries for yet, but is surely a first step through an up-to-date Windows' release.

Fred -