### PR TITLE
Fix w_run refactor

### DIFF
--- a/src/gsb_file.c
+++ b/src/gsb_file.c
@@ -973,10 +973,10 @@ gboolean gsb_file_open_file (const gchar *filename)
 		dialogue_error_hint (tmp_str2, tmp_str1);
 		g_free (tmp_str1);
 		g_free (tmp_str2);
+		w_run->file_modification = 0;
 #endif
 		grisbi_win_status_bar_stop_wait (TRUE);
 		grisbi_win_stack_box_show (NULL, "accueil_page");
-		w_run->file_modification = 0;
 
 		return FALSE;
     }


### PR DESCRIPTION
Le dernier commit sur ce fichier ne compile pas:
```
gsb_file.c: In function ‘gsb_file_open_file’:                                                                                           
gsb_file.c:979:17: error: ‘w_run’ undeclared (first use in this function); did you mean ‘run’?                                          
  979 |                 w_run->file_modification = 0;                                                                                   
         |                 ^~~~~                                                                                                           
         |                 run    
```

En regardant le code, w_run est defini seulement si HAVE_SSL est aussi defini.