### PR TITLE
Add Appstream metadata

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -57,6 +57,7 @@
 [type: gettext/glade]src/widgets/widget_search_transaction.ui
 [type: gettext/glade]src/widgets/widget_transfer.ui
 share/grisbi.desktop.in
+share/grisbi.metainfo.xml.in
 src/accueil.c
 src/bet_data.c
 src/bet_data_finance.c

--- a/po/fr.po
+++ b/po/fr.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fr\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-26 13:43+0200\n"
+"POT-Creation-Date: 2023-08-21 17:15+0200\n"
 "PO-Revision-Date: 2022-06-25 13:16+0200\n"
 "Last-Translator: Pierre Biava <pierre@pierre.biava.name>\n"
 "Language-Team: français <>\n"
@@ -2728,6 +2728,33 @@ msgstr "Gestionnaire de finances personnelles"
 #: ../share/grisbi.desktop.in.h:3
 msgid "finance"
 msgstr "finance"
+
+#: ../share/grisbi.metainfo.xml.in.h:2
+msgid "Personal finances manager"
+msgstr "Gestionnaire de finances personnelles"
+
+#: ../share/grisbi.metainfo.xml.in.h:3
+msgid ""
+"Grisbi is a very functional personal financial management program with a lot "
+"of features: checking, cash and liabilities accounts, several accounts with "
+"automatic contra entries, several currencies, including euro, arbitrary "
+"currency for every operation, money interchange fees, switch to euro account "
+"per account, description of the transactions with third parties, categories, "
+"sub-categories, financial year, notes, breakdown, transfers between "
+"accounts, even for accounts of different currencies, bank reconciliation, "
+"scheduled transactions, automatic recall of last transaction for every third "
+"party, nice and easy user interface, user manual, QIF import/export."
+msgstr ""
+"Grisbi est un logiciel libre de comptabilité personnelle très fonctionnel "
+"comprenant de nombreuses fonctionnalités : compte bancaires, de caisse et de "
+"passif, comptes multiples avec contre-opérations automatiques, devises "
+"multiples incluant l'euro, devise arbitraire pour chaque opération, frais de "
+"conversion, passage à l'euro par compte, description des transactions externes,"
+"catégories, sous-catégories, année fiscale, notes, résumés, transfers entre "
+"comptes même pour des comptes avec des devises différentes, réconciliation "
+"bancaire, transactions programmées, rappel de la dernière transaction pour "
+"chaque tiers, interface simple et agréable, manuel utilisateur, import/export "
+"QIF."
 
 #: ../src/accueil.c:129
 #, c-format

--- a/share/Makefile.am
+++ b/share/Makefile.am
@@ -5,12 +5,17 @@ desktop_in_files = grisbi.desktop.in
 desktop_DATA = $(desktop_in_files:.desktop.in=.desktop)
 @INTLTOOL_DESKTOP_RULE@
 
-EXTRA_DIST = $(desktop_in_files) grisbi.xml grisbi.nsi.in
+appstreamdir = $(datadir)/metainfo/
+appstream_in_files = grisbi.metainfo.xml.in
+appstream_DATA = $(appstream_in_files:.xml.in=.xml)
+@INTLTOOL_XML_RULE@
+
+EXTRA_DIST = $(desktop_in_files) grisbi.xml grisbi.nsi.in $(appstream_in_files)
 
 mimedir = $(datadir)/mime/packages
 mime_DATA = grisbi.xml
 
-DISTCLEANFILES = $(desktop_DATA)
+DISTCLEANFILES = $(desktop_DATA) $(appstream_DATA)
 
 # Key variable for a very own packaging; basically, I use:
 # ./configure --prefix=~/my-inst && make && make install

--- a/share/grisbi.metainfo.xml.in
+++ b/share/grisbi.metainfo.xml.in
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.grisbi.Grisbi</id>
+  <metadata_license>CC0</metadata_license>
+  <project_license>GPL-2.0-or-later</project_license>
+  <_name>Grisbi</_name>
+  <_summary>Personal finances manager</_summary>
+  <description>
+    <_p>
+      Grisbi is a very functional personal financial management program
+      with a lot of features: checking, cash and liabilities accounts,
+      several accounts with automatic contra entries, several currencies,
+      including euro, arbitrary currency for every operation, money
+      interchange fees, switch to euro account per account, description
+      of the transactions with third parties, categories, sub-categories,
+      financial year, notes, breakdown, transfers between accounts, even
+      for accounts of different currencies, bank reconciliation, scheduled
+      transactions, automatic recall of last transaction for every third
+      party, nice and easy user interface, user manual, QIF import/export.
+    </_p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image type="source" width="1039" height="725">http://grisbi.org/public/Screenshots/screnshot-grisbi1.png</image>
+    </screenshot>
+    <screenshot>
+      <image type="source" width="1039" height="725">http://grisbi.org/public/Screenshots/screnshot-ib.png</image>
+    </screenshot>
+    <screenshot>
+      <image type="source" width="1039" height="725">http://grisbi.org/public/Screenshots/screnshot-report.png</image>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://grisbi.org/</url>
+  <content_rating type="oars-1.1" />
+  <launchable type="desktop-id">org.grisbi.Grisbi.desktop</launchable>
+  <releases>
+    <release version="2.0.5" date="2021-08-31">
+      <artifacts>
+        <artifact type="source">
+          <location>http://downloads.sourceforge.net/project/grisbi/grisbi%20stable/2.0.x/2.0.5/grisbi-2.0.5.tar.bz2</location>
+          <checksum type="sha256">bd3adbabfc4b4dfc05eff62d2b36458a24b0f00d07cf35a29f6af2f203c77a3f</checksum>
+        </artifact>
+      </artifacts>
+    </release>
+  </releases>
+</component>


### PR DESCRIPTION
This adds application metadata in the [Appstream format](https://www.freedesktop.org/software/appstream/docs/). It is necessary to show up in application stores such as Gnome Software.