### PR TITLE
Sépare la property d'affichage du nom de compte dans les ops vs titre

### DIFF
--- a/src/etats_affiche.c
+++ b/src/etats_affiche.c
@@ -260,7 +260,7 @@ gint etat_affiche_affiche_titres_colonnes (gint ligne)
 		colonne = colonne + 2;
 	}
 
-	if (gsb_data_report_get_account_show_name (current_report_number))
+	if (gsb_data_report_get_show_report_account_name (current_report_number))
 	{
 		etat_affiche_attach_label (_("Account name"),
 								   TEXT_BOLD,
@@ -607,7 +607,7 @@ gint etat_affiche_affichage_ligne_ope (gint transaction_number,
 			g_free (text);
 	}
 
-	if (gsb_data_report_get_account_show_name (current_report_number))
+	if (gsb_data_report_get_show_report_account_name (current_report_number))
 	{
 
 		text = my_strdup (gsb_data_account_get_name (gsb_data_transaction_get_account_number

--- a/src/etats_calculs.c
+++ b/src/etats_calculs.c
@@ -1395,7 +1395,7 @@ pas_decalage:
 	{
 		nb_colonnes = nb_colonnes + gsb_data_report_get_show_report_date (current_report_number);
 		nb_colonnes = nb_colonnes + gsb_data_report_get_show_report_value_date (current_report_number);
-		nb_colonnes = nb_colonnes + gsb_data_report_get_account_show_name (current_report_number);
+		nb_colonnes = nb_colonnes + gsb_data_report_get_show_report_account_name (current_report_number);
 		nb_colonnes = nb_colonnes + gsb_data_report_get_show_report_payee (current_report_number);
 		nb_colonnes = nb_colonnes + gsb_data_report_get_show_report_category (current_report_number);
 		nb_colonnes = nb_colonnes + gsb_data_report_get_show_report_budget (current_report_number);

--- a/src/etats_prefs.c
+++ b/src/etats_prefs.c
@@ -211,6 +211,7 @@ struct _EtatsPrefsPrivate
 	GtkWidget *		bouton_afficher_exo_opes;
 	GtkWidget *		bouton_afficher_infobd_opes;
 	GtkWidget *		bouton_afficher_no_rappr;
+	GtkWidget *     bouton_afficher_nom_compte_opes;
 	GtkWidget *		bouton_afficher_titres_colonnes;
 	GtkWidget *		bouton_titre_changement;
 	GtkWidget *		bouton_titre_en_haut;
@@ -1926,6 +1927,7 @@ static void etats_prefs_class_init (EtatsPrefsClass *klass)
 	gtk_widget_class_bind_template_child_private (GTK_WIDGET_CLASS (klass), EtatsPrefs, bouton_afficher_exo_opes);
 	gtk_widget_class_bind_template_child_private (GTK_WIDGET_CLASS (klass), EtatsPrefs, bouton_afficher_infobd_opes);
 	gtk_widget_class_bind_template_child_private (GTK_WIDGET_CLASS (klass), EtatsPrefs, bouton_afficher_no_rappr);
+	gtk_widget_class_bind_template_child_private (GTK_WIDGET_CLASS (klass), EtatsPrefs, bouton_afficher_nom_compte_opes);
 	gtk_widget_class_bind_template_child_private (GTK_WIDGET_CLASS (klass), EtatsPrefs, bouton_afficher_titres_colonnes);
 	gtk_widget_class_bind_template_child_private (GTK_WIDGET_CLASS (klass), EtatsPrefs, bouton_titre_changement);
 	gtk_widget_class_bind_template_child_private (GTK_WIDGET_CLASS (klass), EtatsPrefs, bouton_titre_en_haut);
@@ -2868,6 +2870,8 @@ void etats_prefs_initialise_onglet_affichage_operations (GtkWidget *etats_prefs,
 								  gsb_data_report_get_show_report_bank_references (report_number));
 	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (priv->bouton_afficher_no_rappr),
 								  gsb_data_report_get_show_report_marked (report_number));
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (priv->bouton_afficher_nom_compte_opes),
+								  gsb_data_report_get_show_report_account_name (report_number));
 
 	/* affichage des titres des colonnes */
 	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (priv->bouton_afficher_titres_colonnes),
@@ -2983,6 +2987,11 @@ void etats_prefs_recupere_info_onglet_affichage_operations (GtkWidget *etats_pre
 	if (detail_ope && !is_actif)
 		is_actif = TRUE;
 	gsb_data_report_set_show_report_marked (report_number, detail_ope);
+
+	detail_ope = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (priv->bouton_afficher_nom_compte_opes));
+	if (detail_ope && !is_actif)
+		is_actif = TRUE;
+	gsb_data_report_set_show_report_account_name (report_number, detail_ope);
 
 	if (affich_opes && !is_actif)
 		gsb_data_report_set_show_report_transactions (report_number, FALSE);

--- a/src/gsb_data_report.c
+++ b/src/gsb_data_report.c
@@ -84,6 +84,7 @@ struct _ReportStruct {
     gint show_report_method_of_payment_content;
     gint show_report_marked;
     gint show_report_financial_year;
+    gint show_report_account_name;
 
     /** @name stuff showed in the report */
     gint sorting_report;                            /**< 0=date, 1=tr number, 2=payee, 3=categ, 4=budget, 5=notes, 6=method payment, 7=method paym content, 8=voucher, 9=bank ref, 10=marked number */
@@ -1237,6 +1238,50 @@ gboolean gsb_data_report_set_show_report_marked ( gint report_number,
 
     return TRUE;
 }
+
+
+/**
+ * get the  show_report_account_name
+ *
+ * \param report_number the number of the report
+ *
+ * \return the show_report_account_name  of the report, -1 if problem
+ * */
+gint gsb_data_report_get_show_report_account_name ( gint report_number )
+{
+    ReportStruct *report;
+
+    report = gsb_data_report_get_structure (report_number);
+
+    if ( !report )
+	return -1;
+
+    return report -> show_report_account_name;
+}
+
+/**
+ * set the show_report_account_name
+ *
+ * \param report_number number of the report
+ * \param show_report_account_name
+ *
+ * \return TRUE if ok
+ * */
+gboolean gsb_data_report_set_show_report_account_name ( gint report_number,
+                        gint show_report_account_name )
+{
+    ReportStruct *report;
+
+    report = gsb_data_report_get_structure (report_number);
+
+    if ( !report )
+	return FALSE;
+
+    report -> show_report_account_name = show_report_account_name;
+
+    return TRUE;
+}
+
 
 
 /**

--- a/src/gsb_data_report.h
+++ b/src/gsb_data_report.h
@@ -97,6 +97,7 @@ gboolean	gsb_data_report_get_search_report							(gint report_number);
 gint 		gsb_data_report_get_show_m 									(gint report_number);
 gint 		gsb_data_report_get_show_p 									(gint report_number);
 gint 		gsb_data_report_get_show_r 									(gint report_number);
+gint 		gsb_data_report_get_show_report_account_name				(gint report_number);
 gint 		gsb_data_report_get_show_report_bank_references 			(gint report_number);
 gint 		gsb_data_report_get_show_report_budget 						(gint report_number);
 gint 		gsb_data_report_get_show_report_category 					(gint report_number);
@@ -254,6 +255,8 @@ gboolean 	gsb_data_report_set_show_p 									(gint report_number,
                         												 gint show_p);
 gboolean 	gsb_data_report_set_show_r 									(gint report_number,
                         												 gint show_r);
+gboolean 	gsb_data_report_set_show_report_account_name				(gint report_number,
+                        												 gint show_report_account_name);
 gboolean 	gsb_data_report_set_show_report_bank_references 			(gint report_number,
                         												 gint show_report_bank_references);
 gboolean 	gsb_data_report_set_show_report_budget 						(gint report_number,

--- a/src/gsb_file_load.c
+++ b/src/gsb_file_load.c
@@ -4746,6 +4746,13 @@ void gsb_file_load_report_part (const gchar **attribute_names,
         continue;
     }
 
+    if (!strcmp (attribute_names[i], "Show_transaction_account_name"))
+    {
+        gsb_data_report_set_show_report_account_name (report_number, utils_str_atoi (attribute_values[i]));
+        i++;
+        continue;
+    }
+
     if (!strcmp (attribute_names[i], "Show_transaction_payment"))
     {
         gsb_data_report_set_show_report_method_of_payment (report_number,

--- a/src/gsb_file_save.c
+++ b/src/gsb_file_save.c
@@ -2601,6 +2601,7 @@ gulong gsb_file_save_report_part (gulong iterator,
 											  "\t\tShow_transaction_payee=\"%d\"\n"
 											  "\t\tShow_transaction_categ=\"%d\"\n"
 											  "\t\tShow_transaction_sub_categ=\"%d\"\n"
+											  "\t\tShow_transaction_account_name=\"%d\"\n"
 											  "\t\tShow_transaction_payment=\"%d\"\n"
 											  "\t\tShow_transaction_budget=\"%d\"\n"
 											  "\t\tShow_transaction_sub_budget=\"%d\"\n"
@@ -2686,6 +2687,7 @@ gulong gsb_file_save_report_part (gulong iterator,
 											  gsb_data_report_get_show_report_payee (report_number),
 											  gsb_data_report_get_show_report_category (report_number),
 											  gsb_data_report_get_show_report_sub_category (report_number),
+											  gsb_data_report_get_show_report_account_name (report_number),
 											  gsb_data_report_get_show_report_method_of_payment (report_number),
 											  gsb_data_report_get_show_report_budget (report_number),
 											  gsb_data_report_get_show_report_sub_budget (report_number),

--- a/src/ui/etats_prefs.ui
+++ b/src/ui/etats_prefs.ui
@@ -894,6 +894,20 @@ Grisbi will automatically create transactions for all payees from the report</pr
                             <property name="top-attach">4</property>
                           </packing>
                         </child>
+                        <child>
+                          <object class="GtkCheckButton" id="bouton_afficher_nom_compte_opes">
+                            <property name="label" translatable="yes">nom du compte</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="halign">start</property>
+                            <property name="draw-indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">5</property>
+                          </packing>
+                        </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>


### PR DESCRIPTION
Depuis le commit f9f0b866e636f2a198db7acdc46508ac7257eba4, dans les rapports, quand la case à cocher "Titres > Afficher les noms de compte" est activée, une nouvelle colonne est ajoutée dans le rapport pour afficher le nom du compte en plus du titre.

Ce commit ajoute une nouvelle case à cocher dans les propriétés du rapport afin de pouvoir ou non afficher le nom du compte indépendament du titre.