### PR TITLE
   Fix le comportement de la checkbox Report > Titre > Afficher le nom du compte

### DIFF
--- a/src/etats_prefs.c
+++ b/src/etats_prefs.c
@@ -1291,6 +1291,10 @@ static GtkWidget *etats_prefs_onglet_affichage_titles_create_page (EtatsPrefs *p
 	g_signal_connect (G_OBJECT (priv->bouton_group_by_account),
 					  "toggled",
 					  G_CALLBACK (sens_desensitive_pointeur),
+					  priv->bouton_afficher_noms_comptes);
+	g_signal_connect (G_OBJECT (priv->bouton_group_by_account),
+					  "toggled",
+					  G_CALLBACK (sens_desensitive_pointeur),
 					  priv->bouton_affiche_sous_total_compte);
 
 	/* affichage possible des tiers */

--- a/src/ui/etats_prefs.ui
+++ b/src/ui/etats_prefs.ui
@@ -675,7 +675,7 @@ Grisbi will automatically create transactions for all payees from the report</pr
                     <property name="orientation">vertical</property>
                     <property name="spacing">5</property>
                     <child>
-                      <!-- n-columns=3 n-rows=5 -->
+                      <!-- n-columns=3 n-rows=6 -->
                       <object class="GtkGrid" id="grid1">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>


### PR DESCRIPTION
La checkbox "Afficher le nom du compte" n'est utile que si on regroupe les données par compte.    Si le regroupement des données n'est pas activé, cette case a coché n'a aucun effet. Ce comportement est actuellement implémenté sur chaque case à cocher dans les préférences de Titre des rapports, sauf pour le nom du compte.