### PR TITLE
Ajouter l'option à l'utilisateur de parametrer sa feuille d'impression

### DIFF
--- a/src/print_dialog_config.c
+++ b/src/print_dialog_config.c
@@ -70,6 +70,7 @@ void print_dialog_config ( GCallback begin_callback,
 
 	print = gtk_print_operation_new ();
 	gtk_print_operation_set_unit ( print, GTK_UNIT_POINTS );
+	gtk_print_operation_set_embed_page_setup (print, TRUE);
 
 	if (settings != NULL)
 		gtk_print_operation_set_print_settings (print, settings);


### PR DESCRIPTION
Il n'est actuellement pas possible de choisir le format de la feuille ni l'orientation. En assignant true à embed_page_setup, il sera possible pour l'utilisateur de changer ces formats.

C'est très utile quand il y a beaucoup de colonnes à imprimer %)