### PR TITLE
Remove leftover intltool markers

### DIFF
--- a/share/grisbi.metainfo.xml.in
+++ b/share/grisbi.metainfo.xml.in
@@ -3,8 +3,8 @@
   <id>org.grisbi.Grisbi</id>
   <metadata_license>CC0</metadata_license>
   <project_license>GPL-2.0-or-later</project_license>
-  <_name>Grisbi</_name>
-  <_summary>Personal finances manager</_summary>
+  <name>Grisbi</name>
+  <summary>Personal finances manager</summary>
   <description>
     <p>
       Grisbi is a very functional personal financial management program

--- a/share/grisbi.metainfo.xml.in
+++ b/share/grisbi.metainfo.xml.in
@@ -5,6 +5,7 @@
   <project_license>GPL-2.0-or-later</project_license>
   <name>Grisbi</name>
   <summary>Personal finances manager</summary>
+  <developer_name>Grisbi Team</developer_name>
   <description>
     <p>
       Grisbi is a very functional personal financial management program


### PR DESCRIPTION
According to https://wiki.gnome.org/MigratingFromIntltoolToGettext, the underscores markers must be removed from the xml files that need to be translated.