### PR TITLE
Install desktop file as org.grisbi.Grisbi.desktop

### DIFF
--- a/grisbi.spec
+++ b/grisbi.spec
@@ -87,7 +87,7 @@ make %{?_smp_mflags}
 %{_datadir}/doc/%{name}-%{version}/de/*
 %{_datadir}/doc/%{name}-%{version}/en/*
 %{_datadir}/doc/%{name}-%{version}/fr/*
-%{_datadir}/applications/%{name}.desktop
+%{_datadir}/applications/org.grisbi.Grisbi.desktop
 %{_datadir}/glib-2.0/schemas/org.gtk.%{name}.gschema.xml
 %{_datadir}/mime/packages/%{name}.xml
 %{_datadir}/%{name}/ui/%{name}-*.css

--- a/share/Makefile.am
+++ b/share/Makefile.am
@@ -2,8 +2,8 @@ SUBDIRS = categories
 
 desktopdir = $(datadir)/applications
 desktop_in_files = grisbi.desktop.in
-desktop_DATA = $(desktop_in_files:.desktop.in=.desktop)
-grisbi.desktop: grisbi.desktop.in
+desktop_DATA = $(desktop_in_files:grisbi.desktop.in=org.grisbi.Grisbi.desktop)
+org.grisbi.Grisbi.desktop: grisbi.desktop.in
 	$(AM_V_GEN)$(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
 if ! WIN32


### PR DESCRIPTION
The appstream metadata for this project specifies: `<launchable type="desktop-id">org.grisbi.Grisbi.desktop</launchable>`

Install the .desktop file as such so they match up.

Fixes appstream-builder generation for this package.