### PR TITLE
Restore window size and position at launch

### DIFF
--- a/src/grisbi_app.c
+++ b/src/grisbi_app.c
@@ -274,14 +274,11 @@ static void grisbi_app_save_win_geometry_data (GrisbiApp *app,
 
 	priv = grisbi_app_get_instance_private (GRISBI_APP (app));
 
-	if ((priv->a_conf)->full_screen == 0 && (priv->a_conf)->maximize_screen == 0)
-	{
-		/* sauvegarde la position de la fenetre principale */
-		gtk_window_get_position (GTK_WINDOW (win), &(priv->a_conf)->x_position, &(priv->a_conf)->y_position);
+	/* sauvegarde la position de la fenetre principale */
+	gtk_window_get_position (GTK_WINDOW (win), &(priv->a_conf)->x_position, &(priv->a_conf)->y_position);
 
-		/* sauvegarde de la taille de la fenêtre si nécessaire */
-		gtk_window_get_size (GTK_WINDOW (win), &(priv->a_conf)->main_width, &(priv->a_conf)->main_height);
-	}
+	/* sauvegarde de la taille de la fenêtre si nécessaire */
+	gtk_window_get_size (GTK_WINDOW (win), &(priv->a_conf)->main_width, &(priv->a_conf)->main_height);
 }
 
 /**
@@ -306,15 +303,9 @@ static void grisbi_app_change_fullscreen_state (GSimpleAction *action,
 
 	win = GTK_WINDOW (grisbi_app_get_active_window (app));
 	if (g_variant_get_boolean (state))
-	{
-		(priv->a_conf)->full_screen = TRUE;
 		gtk_window_fullscreen (win);
-	}
 	else
-	{
-		(priv->a_conf)->full_screen = FALSE;
 		gtk_window_unfullscreen (win);
-	}
 
 	g_simple_action_set_state (action, state);
 }

--- a/src/grisbi_conf.c
+++ b/src/grisbi_conf.c
@@ -134,10 +134,8 @@ static void grisbi_conf_clean_config (GrisbiAppConf *a_conf)
     a_conf->transactions_list_secondary_sorting = 0;		/* "Sort by transaction number" */
 
     /* settings_geometry */
-	a_conf->full_screen = FALSE;
     a_conf->main_height = WIN_MIN_HEIGHT;
     a_conf->main_width = WIN_MIN_WIDTH;
-    a_conf->maximize_screen = FALSE;
     a_conf->x_position = WIN_POS_X;
    	a_conf->y_position= WIN_POS_Y;
 
@@ -589,10 +587,6 @@ gboolean grisbi_conf_load_app_config (void)
 															"Geometry",
 													    	"low-definition-screen",
 													    	NULL);
-	a_conf->full_screen = g_key_file_get_boolean (config,
-												  "Geometry",
-												  "fullscreen",
-												  NULL);
     a_conf->main_height = g_key_file_get_integer (config,
 												  "Geometry",
 												  "main-height",
@@ -601,10 +595,6 @@ gboolean grisbi_conf_load_app_config (void)
 												 "Geometry",
 												 "main-width",
 												 NULL);
-    a_conf->maximize_screen = g_key_file_get_boolean (config,
-													  "Geometry",
-													  "maximized",
-													  NULL);
     a_conf->x_position = g_key_file_get_integer (config,
 												 "Geometry",
 												 "x-position",
@@ -1044,10 +1034,6 @@ gboolean grisbi_conf_save_app_config (void)
 							"Geometry",
 							"low-definition-screen",
 							a_conf->low_definition_screen);
-	g_key_file_set_boolean (config,
-							"Geometry",
-							"fullscreen",
-                        	a_conf->full_screen);
     g_key_file_set_integer (config,
 							"Geometry",
                         	"main-height",
@@ -1056,10 +1042,6 @@ gboolean grisbi_conf_save_app_config (void)
 							"Geometry",
                         	"main-width",
                         	a_conf->main_width);
-    g_key_file_set_boolean (config,
-							"Geometry",
-                        	"maximized",
-                        	a_conf->maximize_screen);
     g_key_file_set_integer (config,
 							"Geometry",
                         	"x-position",

--- a/src/grisbi_win.c
+++ b/src/grisbi_win.c
@@ -829,36 +829,6 @@ static void grisbi_win_no_file_page_new (GrisbiWin *win)
 	gtk_widget_show_all (priv->no_file_frame);
 }
 
-/* WIN CALLBACK */
-/**
- * check on any change on the main window
- * for now, only to check if we set/unset the full-screen
- *
- * \param window
- * \param event
- * \param null
- *
- * \return FALSE
- * */
-static gboolean grisbi_win_change_state_window (GtkWidget *window,
-												GdkEventWindowState *event,
-												gpointer null)
-{
-	GrisbiAppConf *a_conf;
-
-	a_conf = grisbi_app_get_a_conf ();
-
-	/* en premier on fixe a_conf->maximize_screen */
-	if (event->changed_mask & GDK_WINDOW_STATE_MAXIMIZED)
-	{
-		gboolean show;
-
-		show = !(event->new_window_state & GDK_WINDOW_STATE_MAXIMIZED);
-		a_conf->maximize_screen = !show;
-	}
-
-	return FALSE;
-}
 
 /* FREE STRUCTURES */
 /**
@@ -1004,9 +974,6 @@ static void grisbi_win_class_init (GrisbiWinClass *class)
 	gtk_widget_class_bind_template_child_private (GTK_WIDGET_CLASS (class), GrisbiWin, statusbar);
 	gtk_widget_class_bind_template_child_private (GTK_WIDGET_CLASS (class), GrisbiWin, no_file_frame);
 	gtk_widget_class_bind_template_child_private (GTK_WIDGET_CLASS (class), GrisbiWin, no_file_grid);
-
-	/* signaux */
-	gtk_widget_class_bind_template_callback (GTK_WIDGET_CLASS (class), grisbi_win_change_state_window);
 }
 
 /******************************************************************************/
@@ -1755,14 +1722,6 @@ void grisbi_win_set_size_and_position (GtkWindow *win)
 
 	/* display window at position */
 	gtk_window_move (GTK_WINDOW (win), a_conf->x_position, a_conf->y_position);
-
-	/* set the full screen if necessary */
-	if (a_conf->full_screen)
-		gtk_window_fullscreen (GTK_WINDOW (win));
-
-	/* put up the screen if necessary */
-	if (a_conf->maximize_screen)
-		gtk_window_maximize (GTK_WINDOW (win));
 }
 
 /**

--- a/src/structures.h
+++ b/src/structures.h
@@ -283,8 +283,6 @@ struct _GrisbiAppConf
     gint        main_width;                                 /* main_window width */
     gint        main_height;                                /* main_window height */
 	gboolean	low_definition_screen;						/* TRUE use a low resolution screen */
-    gboolean    full_screen;                                /* TRUE to full screen, 0 else */
-    gboolean    maximize_screen;                            /* TRUE to maximize screen, 0 else */
 
 /* panel part */
     gboolean 	active_scrolling_left_pane;                 /* TRUE active mouse scrolling in the left_pane. */


### PR DESCRIPTION
We ignore the fullscreen & maximized states.
We just restore the window at the position and size it was previously using.

Closes: https://www.grisbi.org/bugsreports/view.php?id=2302