### PR TITLE
feat: new inline search bar in the transactions list

### DIFF
--- a/src/gsb_transactions_list.c
+++ b/src/gsb_transactions_list.c
@@ -124,6 +124,15 @@ static const gchar *labels_titres_colonnes_liste_ope[] = {	/* names of the data 
     N_("Transaction number"),
     N_("Cheque number"),
     NULL };
+
+static const gchar * const search_type_labels[] = {
+	N_("Payee name"),
+	N_("Note"),
+	N_("Payee and note"),
+	N_("Budgetary line"),
+	N_("Category"),
+	NULL
+};
 /*END_STATIC*/
 
 /*START_GLOBAL*/
@@ -139,8 +148,284 @@ GSList *orphan_child_transactions = NULL;
 /*END_EXTERN*/
 
 /******************************************************************************/
+/* Search bar (toolbar) state                                                 */
+/******************************************************************************/
+static GtkWidget *transactions_search_entry = NULL;
+static GtkWidget *transactions_search_combo = NULL;
+
+typedef enum
+{
+	TRANSACTIONS_SEARCH_PAYEE = 1,
+	TRANSACTIONS_SEARCH_NOTE = 2,
+	TRANSACTIONS_SEARCH_PAYEE_AND_NOTE = 3,
+	TRANSACTIONS_SEARCH_BUDGETARY_LINE = 4,
+	TRANSACTIONS_SEARCH_CATEGORY = 5
+} TransactionsSearchType;
+
+static TransactionsSearchType transactions_search_type = TRANSACTIONS_SEARCH_PAYEE_AND_NOTE;
+#define TRANSACTIONS_SEARCH_MIN_CHARS 3
+
+static void gsb_transactions_list_update_search_filter (void);
+static gboolean gsb_transactions_list_transaction_match_search (gint transaction_number);
+static void transactions_search_set_entry_state (const gchar *state);
+static gint transactions_search_count_matches (gint account_number);
+static void transactions_search_entry_icon_released (GtkEntry *entry,
+													 GtkEntryIconPosition icon_pos,
+													 GdkEvent *event,
+													 gpointer user_data);
+
+/******************************************************************************/
 /* Private functions                                                          */
 /******************************************************************************/
+static void transactions_search_entry_changed (GtkEditable *editable, gpointer user_data)
+{
+	const gchar *text;
+
+	(void) user_data;
+	text = gtk_entry_get_text (GTK_ENTRY (editable));
+	/* keep focus on the entry while editing */
+	gtk_widget_grab_focus (GTK_WIDGET (editable));
+
+	/* show/hide the clear icon depending on content */
+	if (text && *text)
+	{
+		gtk_entry_set_icon_from_icon_name (GTK_ENTRY (editable), GTK_ENTRY_ICON_SECONDARY, "edit-clear");
+		gtk_entry_set_icon_tooltip_text (GTK_ENTRY (editable), GTK_ENTRY_ICON_SECONDARY, _("Clear"));
+		gtk_entry_set_icon_sensitive (GTK_ENTRY (editable), GTK_ENTRY_ICON_SECONDARY, TRUE);
+	}
+	else
+	{
+		gtk_entry_set_icon_from_icon_name (GTK_ENTRY (editable), GTK_ENTRY_ICON_SECONDARY, NULL);
+		gtk_entry_set_icon_sensitive (GTK_ENTRY (editable), GTK_ENTRY_ICON_SECONDARY, FALSE);
+	}
+	gsb_transactions_list_update_search_filter ();
+}
+
+static void transactions_search_combo_changed (GtkComboBox *cb, gpointer user_data)
+{
+	gint idx;
+	(void) user_data;
+	idx = gtk_combo_box_get_active (cb);
+	transactions_search_type = (TransactionsSearchType) (idx + 1); /* 1..6 */
+	gsb_transactions_list_update_search_filter ();
+	/* return focus to the entry after changing selector */
+	if (transactions_search_entry)
+		gtk_widget_grab_focus (transactions_search_entry);
+}
+
+static void transactions_search_reset_clicked (GtkToolButton *btn, gpointer user_data)
+{
+	(void) btn;
+	(void) user_data;
+	if (transactions_search_entry)
+		gtk_entry_set_text (GTK_ENTRY (transactions_search_entry), "");
+	transactions_search_type = TRANSACTIONS_SEARCH_PAYEE_AND_NOTE;
+	if (transactions_search_combo)
+		gtk_combo_box_set_active (GTK_COMBO_BOX (transactions_search_combo), 2);
+	gsb_transactions_list_update_search_filter ();
+	/* restore focus to entry */
+	if (transactions_search_entry)
+		gtk_widget_grab_focus (transactions_search_entry);
+}
+
+static void transactions_search_entry_icon_released (GtkEntry *entry,
+													GtkEntryIconPosition icon_pos,
+													GdkEvent *event,
+													gpointer user_data)
+{
+	(void) event;
+	(void) user_data;
+	if (icon_pos != GTK_ENTRY_ICON_SECONDARY)
+		return;
+
+	/* Reuse existing reset logic */
+	transactions_search_reset_clicked (NULL, NULL);
+	/* Keep focus */
+	gtk_widget_grab_focus (GTK_WIDGET (entry));
+}
+
+static void gsb_transactions_list_update_search_filter (void)
+{
+	gint account_number;
+	gint len = 0;
+	gint matches = 0;
+	const gchar *text = NULL;
+
+	account_number = gsb_gui_navigation_get_current_account ();
+
+	if (transactions_search_entry)
+		text = gtk_entry_get_text (GTK_ENTRY (transactions_search_entry));
+	if (text)
+		len = g_utf8_strlen (text, -1);
+
+	/* no external reset button; clear icon lives inside the entry */
+
+	/* visual state of the entry */
+	if (!text || len == 0)
+	{
+		transactions_search_set_entry_state ("neutral");
+	}
+	else if (len < TRANSACTIONS_SEARCH_MIN_CHARS)
+	{
+		transactions_search_set_entry_state ("too_short");
+	}
+	else
+	{
+		matches = transactions_search_count_matches (account_number);
+		if (matches > 0)
+			transactions_search_set_entry_state ("match");
+		else
+			transactions_search_set_entry_state ("no_match");
+	}
+
+	gsb_transactions_list_update_tree_view (account_number, FALSE);
+	/* ensure focus remains on the search entry after refresh */
+	if (transactions_search_entry)
+		gtk_widget_grab_focus (transactions_search_entry);
+}
+
+static void transactions_search_set_entry_state (const gchar *state)
+{
+	GtkStyleContext *context;
+
+	if (!transactions_search_entry)
+		return;
+
+	context = gtk_widget_get_style_context (transactions_search_entry);
+	gtk_style_context_remove_class (context, "transactions-search-too-short");
+	gtk_style_context_remove_class (context, "transactions-search-no-match");
+	gtk_style_context_remove_class (context, "transactions-search-match");
+
+	if (state && strcmp (state, "too_short") == 0)
+		gtk_style_context_add_class (context, "transactions-search-too-short");
+	else if (state && strcmp (state, "no_match") == 0)
+		gtk_style_context_add_class (context, "transactions-search-no-match");
+	else if (state && strcmp (state, "match") == 0)
+		gtk_style_context_add_class (context, "transactions-search-match");
+}
+
+static gint transactions_search_count_matches (gint account_number)
+{
+	GSList *tmp_list;
+	gint count = 0;
+	gboolean r_shown;
+
+	if (account_number <= 0)
+		return 0;
+
+	r_shown = gsb_data_account_get_r (account_number);
+
+	/* never search in archives: use the non-archived list */
+	tmp_list = gsb_data_transaction_get_transactions_list ();
+	while (tmp_list)
+	{
+		TransactionStruct *transaction;
+		gint transaction_number;
+
+		transaction = tmp_list->data;
+		transaction_number = gsb_data_transaction_get_transaction_number (transaction);
+
+		if (transaction_number > 0
+			&& gsb_data_transaction_get_account_number (transaction_number) == account_number)
+		{
+			/* respect "hide reconciled" setting */
+			if (gsb_data_transaction_get_marked_transaction (transaction_number) == OPERATION_RAPPROCHEE
+				&& !r_shown)
+			{
+				tmp_list = tmp_list->next;
+				continue;
+			}
+
+			if (gsb_transactions_list_transaction_match_search (transaction_number))
+				count++;
+		}
+
+		tmp_list = tmp_list->next;
+	}
+
+	return count;
+}
+
+static gboolean gsb_transactions_list_transaction_match_search (gint transaction_number)
+{
+	const gchar *needle;
+	gboolean match = FALSE;
+
+	/* get the current query from the entry to avoid any desync */
+	if (!transactions_search_entry)
+		return TRUE;
+
+	needle = gtk_entry_get_text (GTK_ENTRY (transactions_search_entry));
+	if (!needle)
+		return TRUE;
+	if (g_utf8_strlen (needle, -1) < TRANSACTIONS_SEARCH_MIN_CHARS)
+		return TRUE;
+
+	switch (transactions_search_type)
+	{
+		case TRANSACTIONS_SEARCH_PAYEE:
+		{
+			const gchar *payee_name;
+			if (gsb_data_transaction_get_mother_transaction_number (transaction_number))
+				return FALSE;
+			payee_name = gsb_data_payee_get_name (gsb_data_transaction_get_payee_number (transaction_number), TRUE);
+			if (payee_name && utils_str_my_case_strstr (payee_name, needle))
+				match = TRUE;
+			break;
+		}
+		case TRANSACTIONS_SEARCH_NOTE:
+		{
+			const gchar *note = gsb_data_transaction_get_notes (transaction_number);
+			if (note && utils_str_my_case_strstr (note, needle))
+				match = TRUE;
+			break;
+		}
+		case TRANSACTIONS_SEARCH_PAYEE_AND_NOTE:
+		{
+			const gchar *note = gsb_data_transaction_get_notes (transaction_number);
+			if (note && utils_str_my_case_strstr (note, needle))
+			{
+				match = TRUE;
+				break;
+			}
+			if (!gsb_data_transaction_get_mother_transaction_number (transaction_number))
+			{
+				const gchar *payee_name = gsb_data_payee_get_name (gsb_data_transaction_get_payee_number (transaction_number), TRUE);
+				if (payee_name && utils_str_my_case_strstr (payee_name, needle))
+					match = TRUE;
+			}
+			break;
+		}
+		case TRANSACTIONS_SEARCH_BUDGETARY_LINE:
+		{
+			gint b = gsb_data_transaction_get_budgetary_number (transaction_number);
+			gint sb = gsb_data_transaction_get_sub_budgetary_number (transaction_number);
+			gchar *name = gsb_data_budget_get_name (b, sb, NULL);
+			if (name)
+			{
+				if (utils_str_my_case_strstr (name, needle))
+					match = TRUE;
+				g_free (name);
+			}
+			break;
+		}
+		case TRANSACTIONS_SEARCH_CATEGORY:
+		{
+			gchar *name = gsb_data_transaction_get_category_real_name (transaction_number);
+			if (name)
+			{
+				if (utils_str_my_case_strstr (name, needle))
+					match = TRUE;
+				g_free (name);
+			}
+			break;
+		}
+		default:
+			match = TRUE;
+	}
+
+	return match;
+}
 /**
  *  Check that a transaction is selected
  *
@@ -2582,6 +2867,49 @@ static GtkWidget *gsb_transactions_list_new_toolbar (void)
 
     gtk_toolbar_insert (GTK_TOOLBAR (toolbar), separator, -1);
 
+    /* search entry (right side) */
+    {
+        GtkToolItem *search_item;
+        GtkWidget *entry;
+
+        search_item = gtk_tool_item_new ();
+        entry = gtk_entry_new ();
+        gtk_entry_set_placeholder_text (GTK_ENTRY (entry), _("Search"));
+        gtk_entry_set_width_chars (GTK_ENTRY (entry), 30);
+        gtk_widget_set_size_request (entry, 260, -1);
+        gtk_widget_set_tooltip_text (entry, _("Type at least 4 characters to filter"));
+		g_signal_connect (G_OBJECT (entry),
+						  "icon-release",
+						  G_CALLBACK (transactions_search_entry_icon_released),
+						  NULL);
+        g_signal_connect (G_OBJECT (entry),
+                          "changed",
+                          G_CALLBACK (transactions_search_entry_changed),
+                          NULL);
+        gtk_container_add (GTK_CONTAINER (search_item), entry);
+        gtk_toolbar_insert (GTK_TOOLBAR (toolbar), search_item, -1);
+        transactions_search_entry = entry;
+    }
+
+    /* search selector */
+    {
+        GtkToolItem *combo_item;
+        GtkWidget *combo;
+        combo_item = gtk_tool_item_new ();
+        combo = gtk_combo_box_text_new ();
+		/* mapping kept in the insertion order (see TransactionsSearchType) */
+		for (gint i = 0; search_type_labels[i]; i++)
+			gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo), _(search_type_labels[i]));
+        gtk_combo_box_set_active (GTK_COMBO_BOX (combo), 2); /* default to Payee and note */
+        g_signal_connect (G_OBJECT (combo),
+                          "changed",
+                          G_CALLBACK (transactions_search_combo_changed),
+                          NULL);
+        gtk_container_add (GTK_CONTAINER (combo_item), combo);
+        gtk_toolbar_insert (GTK_TOOLBAR (toolbar), combo_item, -1);
+        transactions_search_combo = combo;
+    }
+
     /* archive button */
     item = utils_buttons_tool_button_new_from_image_label ("gsb-archive-24.png", _("Recreates archive"));
     gtk_widget_set_tooltip_text (GTK_WIDGET (item),
@@ -2769,6 +3097,7 @@ GtkWidget *gsb_transactions_list_creation_fenetre_operations (void)
 
     GtkWidget *win_operations;
     GtkWidget *frame;
+    GtkWidget *toolbar_box;
 	GtkWidget *vbox_transactions_list = NULL; /* adr de la vbox qui contient les opés de chaque compte */
 
     /* la fenetre des opé est une vbox : la barre d'outils en haut et la liste en bas */
@@ -2778,9 +3107,13 @@ GtkWidget *gsb_transactions_list_creation_fenetre_operations (void)
     frame = gtk_frame_new (NULL);
     gtk_box_pack_start (GTK_BOX (win_operations), frame, FALSE, FALSE, 0);
 
+    /* vbox inside the frame: toolbar + search info label */
+    toolbar_box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 2);
+    gtk_container_add (GTK_CONTAINER (frame), toolbar_box);
+
     /* création de la barre d'outils */
     transaction_toolbar = gsb_transactions_list_new_toolbar ();
-    gtk_container_add (GTK_CONTAINER (frame), transaction_toolbar);
+    gtk_box_pack_start (GTK_BOX (toolbar_box), transaction_toolbar, FALSE, FALSE, 0);
 
     /* vbox_transactions_list will contain the tree_view, we will see later to set it directly */
     vbox_transactions_list = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
@@ -4145,6 +4478,10 @@ gboolean gsb_transactions_list_transaction_visible (gpointer transaction_ptr,
 	 &&
 	 !r_shown)
 	return FALSE;
+
+    /* search filter: only apply when query length >= min chars */
+	if (!gsb_transactions_list_transaction_match_search (transaction_number))
+		return FALSE;
 
     /* 	    now we check if we show 1, 2, 3 or 4 lines */
     return transaction_list_check_line_is_visible (line_in_transaction, nb_rows);

--- a/src/ui/grisbi-widgets.css
+++ b/src/ui/grisbi-widgets.css
@@ -5,6 +5,22 @@ combobox arrow {
     -gtk-icon-source: -gtk-icontheme("pan-down-symbolic");
 }
 
+/* Transactions list: search entry states */
+entry.transactions-search-too-short {
+	background-color: #fff2b3;
+	background-image: none;
+}
+
+entry.transactions-search-match {
+	background-color: #ccffcc;
+	background-image: none;
+}
+
+entry.transactions-search-no-match {
+	background-color: #ffcccc;
+	background-image: none;
+}
+
 /************/
 /* private  */
 /************/


### PR DESCRIPTION
This is a filter as you type search, the aim is to quickly search for a past transaction instead of scrolling for a long time or opening the search window.

So it does not replace the existing Search function whose output is slightly different:
* existing Search: will select each transaction matching the criteria
* inline search: will only show the matching transactions

We are using color code:
* yellow -> does not match search requirements (at least 3 characters -> should we make it configurable) <img width="1330" height="180" alt="search-tooshort" src="https://github.com/user-attachments/assets/4981247d-7607-4502-bdf7-c7ba8bc9fc92" />
* green -> at least 1 transaction matching <img width="1330" height="166" alt="search-match" src="https://github.com/user-attachments/assets/e015ee6a-a0a1-4db5-ae0d-4dd436c1035b" />
* red -> no matching transactions <img width="1330" height="180" alt="search-no-match" src="https://github.com/user-attachments/assets/eb745791-b63f-48f8-81be-36d9eb958f9f" />

Tested: Ubuntu 22.04
